### PR TITLE
feat(shell): launch managed app surfaces via gateway

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,204 +1,145 @@
-# Constitute – Architecture Overview
+# Constitute - Architecture Overview
 
-Constitute is a browser-native, decentralized identity and device association system built around cryptographic device identity, relay-based signaling, and progressive movement toward peer-to-peer swarm synchronization. The project is intentionally modular and transport-agnostic, with security and identity primitives implemented first, and higher-level collaboration features layered on top.
+`constitute` is the browser-native management shell for the Constitution ecosystem.
+It owns identity, device, pairing, gateway, zone, and managed-service control UX.
 
-This document orients contributors to the current structure, module responsibilities, and roadmap direction.
+It does not permanently embed every first-party application inside the shell. Instead, it launches managed app surfaces that publish separately under the same site domain.
 
 ## Core Concepts
 
 ### Identity
-An Identity is a logical grouping of devices.
-It is not a username or profile — it is a cryptographic association set.
-
-- Stored as shared state across associated devices
-- Contains:
-  - Identity label (human-readable)
-  - Identity ID (stable unique identifier)
-  - Device list
-  - Room/shared keys (for encrypted state)
-- Exists as a “room” concept over relay transport today, swarm later
+An identity is the trust domain / owner grouping:
+- identity label
+- identity id
+- approved devices
+- approved service-backed devices
 
 ### Device
-A Device is a cryptographic endpoint.
+A paired endpoint acting for an identity.
 
-- Has a DID-like identifier
-- May be:
-  - Software-backed (soft key)
-  - Platform-backed (WebAuthn / TPM)
-- Has a required human label
-- Devices can be approved or rejected by existing devices in the identity
+### Service-Backed Device
+A native runtime with its own keypair that still publishes as a device record.
 
-### Pairing
-Pairing is the process of associating a new device to an identity.
+Examples:
+- owned gateway
+- hosted NVR service
 
-- Device requests pairing
-- Existing device approves or rejects
-- Approval results in:
-  - Device added to identity
-  - Shared keys exchanged
-  - Request resolved at source
-- Pending requests must never persist after resolution
+### Gateway
+A special service-backed device that:
+- brokers browser launch/signaling
+- inventories hosted services
+- enforces managed-service capability checks
 
-### Notifications
-Notifications are identity-scoped state.
+## Shell Responsibilities
+`constitute` owns:
+- onboarding
+- device creation and pairing approval
+- identity lifecycle
+- zone management
+- gateway inventory and freshness
+- hosted service inventory
+- managed app launch
 
-- Represent events such as pairing requests or approvals
-- Stored as structured data, not UI artifacts
-- Support:
-  - Clear
-  - Remove
-  - Sync across devices (configurable per-device vs global)
+`constitute` does not own:
+- long-running native transport
+- camera ingest or retention
+- direct service-specific media pipelines
 
-## High-Level Architecture
+## UI Structure
+
+### Management Shell
+The shell remains at `tld/constitute/` and is responsible for:
+- Home
+- Settings
+- pairing and identity management
+- devices and service-backed devices
+- appliances/gateway management
+- launch entry points for managed apps
+
+### Managed App Surfaces
+First-party apps publish separately, for example:
+- `tld/constitute-nvr-ui/`
+
+The shell launches these in a new tab or window and provides a short-lived launch context instead of long-lived secrets in the URL.
+
+## Runtime Structure
 
 Browser UI
-- app.js
-  - Activity routing (Home / Settings / Onboarding)
-  - Navigation drawer + notification bell
-  - SharedWorker relay bridge
-- identity/client.js
-  - RPC bridge to Service Worker daemon
-- relay.worker.js (SharedWorker)
-  - Persistent WebSocket transport
+- `app.js`
+  - shell routes and appliances, launcher flow, and peer/service presentation
+- `identity/client.js`
+  - window-to-Service Worker RPC bridge
+- `relay.worker.js`
+  - persistent WebSocket relay bridge
 
-Service Worker (Identity Daemon)
-- identity/sw/daemon.js
-  - Device state
-  - Identity state
-  - Pairing lifecycle
-  - Notifications state
-  - Relay frame handling
-- identity/sw/idb.js
-  - IndexedDB abstraction
-- identity/sw/crypto.js
-  - Signing / encryption helpers
-- identity/sw/nostr.js
-  - Relay event formatting / signing
-- identity/sw/zone.js
-  - Zone key derivation + presence
-- identity/sw/directory.js
-  - Device directory store
+Service Worker
+- `identity/sw/daemon.js`
+  - identity, device, pairing, and relay state authority
+- `identity/sw/rpc.js`
+  - RPC surface for shell actions
+- `identity/sw/relayIn.js`
+  - relay ingest and event dispatch
+- `identity/sw/*`
+  - storage, crypto, Nostr, zone, and directory helpers
 
-## Transport Layers
+## Transport Direction
 
-### Current
-- WebSocket Relay (Nostr-style)
-- SharedWorker owns persistent connection
-- Service Worker owns signing, parsing, and state updates
-- Window only transports frames, never secrets
+### Current Browser Authority
+- Service Worker is the cryptographic/state authority.
+- SharedWorker holds long-lived relay transport.
+- Windows never own long-lived secret authority directly.
 
-### Planned
-- Gateway Backbone (native)
-  - QUIC/UDP mesh
-  - Relay/bridge mode for browsers
-  - Federated/volunteer relays (no single owner)
-- Browser Swarm Transport
-  - WebRTC + TURN fallback
-  - Relay used only for bootstrap/signaling
-  - Encrypted room state synchronization
+### Managed-Service Direction
+- browser app surfaces should attach to owned services through owned gateways
+- gateway remains the control/auth boundary
+- WebRTC is the preferred browser-safe transport direction for managed live media and direct paths
+- shell launch/bootstrap must stay separate from media transport
 
-## Discovery + Directory
-
-Zones are the discovery scope. Devices join zones via a sharable link (zone key).
-
-- Zone keys are generated at creation time (randomized, human label stored locally)
-- Zone presence + member lists are published over relay
-- Directory is a local store of discovered devices
-- Directory powers Peers (discovery) and future apps
-
+## Discovery and Directory
+Zones remain the discovery scope:
+- zone keys are operator/user-shared
+- directory stores discovered devices and service-backed devices
+- service-backed devices must render distinctly from user devices
+- appliance inventory should show host relationship, freshness, and launch availability
 
 ## State Storage
 
 ### IndexedDB
-Authoritative local state store.
+Authoritative local state store:
+- device metadata
+- identity metadata
+- pairing requests
+- notifications
+- discovered devices
+- discovered service-backed devices
+- zone memberships
 
-Stores:
-- Device metadata
-- Identity metadata
-- Pairing requests
-- Notifications
-- Blocked devices
-- Directory entries
-- Zone list
-
-### Relay / Room State
-Ephemeral + syncable channel.
-
+### Relay and App-Channel State
 Used for:
-- Pairing request broadcast
-- Pair approval events
-- Notifications clear sync (optional)
-- Device/identity label updates
-- Zone presence
+- pairing requests/approvals
+- device and identity label updates
+- gateway/service status events
+- discovery and zone presence
+- managed launch/signaling coordination
 
 ## Security Model
+- device-level signing remains mandatory
+- Service Worker remains the cryptographic authority for shell state
+- long-lived identity secrets must not be passed in app launch URLs
+- managed app surfaces should redeem short-lived launch context
+- relay transport remains untrusted and validation-bound
 
-- Device-level signing mandatory
-- WebAuthn / TPM encouraged during onboarding
-- Software fallback supported
-- Room keys symmetric, distributed via trusted device approval
-- UI never holds secret keys
-- Service Worker is cryptographic authority
-
-## Pairing Lifecycle Rules
-
-1. Request created -> status = pending
-2. Approval or rejection:
-   - Status updated immediately
-   - Identity device list updated
-   - Notification emitted
-3. Pending lists only show pending
-4. Requests referencing known devices are auto-filtered
-5. Requester device auto-advances to Home when approved
-
-## Notifications Rules
-
-- Stored as structured objects
-- Clearing updates data store, not just UI
-- May propagate as room state
-- Never persist “phantom” items after resolution
-
-## Roadmap
-
-### Near Term
-- Stabilize zone list propagation + naming
-- Clean up Peers UX
-
-### Mid Term
-- P0: constitute-gateway repo (native backbone)
-- P2: browser swarm transport (TURN-backed)
-- P3: codebase refactor + module boundaries
-- Shared encrypted data layers
-- Messaging maturation + double-ratchet encryption
-
-### Long Term
-- Full decentralized app substrate
-- Identity-scoped application namespaces
-- Cross-app identity federation
-- Plugin / module system
+## Active Convergence Slice
+`constitute` is converging toward:
+- service-backed device rendering (`deviceKind = user|service`)
+- gateway-managed launch authorization
+- Pages-native app surfaces (`tld/<repo-name>/`)
+- managed NVR launch into `constitute-nvr-ui`
+- WebRTC live preview as the managed browser media direction
 
 ## Design Principles
-
-- Transport agnostic
-- Security first
-- State authoritative in daemon
-- UI is observer, not source of truth
-- Progressive decentralization
-- Minimal implicit trust
-- Deterministic lifecycle resolution
-
-## Gateway Convergence (Active)
-Web convergence is currently targeting `constitute-gateway/docs/PROTOCOL.md` as contract source.
-
-Current alignment slice:
-- canonical app-channel request envelope support (`swarm_record_request` + legacy alias compatibility)
-- DHT request plumbing (`swarm_dht_get`, `swarm_dht_put`) and local DHT record handling
-- relay ingest hardening (signature verification + timestamp/TTL window checks before mutation)
-- discovery/presence role metadata parity (`role`, `serviceVersion`)
-- service-advertised app module hints (`uiRepo`, `uiRef`, optional `uiManifestUrl`) consumed before static role maps
-
-Exit criteria for this slice:
-- web emits and consumes gateway canonical envelopes without regressions
-- invalid/expired relay envelopes are ignored consistently
-- docs reflect current parity state and known remaining gaps
-
+- management shell and app surfaces stay separate
+- gateway remains the canonical browser control boundary
+- transport choice must not redefine trust
+- service-backed devices participate in the same identity model
+- launch context is short-lived and explicit

--- a/README.md
+++ b/README.md
@@ -1,20 +1,22 @@
 # Constitute
 
-Browser-native identity and discovery client for the Constitution ecosystem.
-`constitute` is the web-side runtime that converges against `constitute-gateway` contracts.
+Browser-native management shell for the Constitution ecosystem.
+`constitute` owns identity, pairing, zones, gateway inventory, hosted-service management, and managed app launch.
 
 ## Status
 - Prototype: active development
 - Discovery bootstrap: implemented (zones + directory)
-- Gateway contract convergence: in progress (app-channel parity + ingest hardening)
-- Browser swarm transport: staged behind gateway-first convergence
+- Gateway-managed launch and service-backed device convergence: active
+- Managed NVR launch to separate app surface: active
 
 ## Key Concepts
 - Identity: cryptographic grouping of devices
 - Device: cryptographic endpoint (software or WebAuthn-backed)
+- Service-backed device: native runtime with its own keypair, still published as a device record
 - Pairing: approval-based device association
 - Zone: discovery scope joined via shared key
-- Directory: local cache of discovered peers
+- Gateway: owned browser control boundary and hosted-service inventory owner
+- Directory: local cache of discovered peers and services
 
 ## Current Features
 - Device identity lifecycle (software + optional WebAuthn)
@@ -24,12 +26,11 @@ Browser-native identity and discovery client for the Constitution ecosystem.
 - Zone presence/list propagation and directory updates
 - Swarm record cache (identity/device) with signed record validation
 - Canonical app-channel plumbing for `swarm_record_request` and `swarm_dht_get/put`
-- Manifest-driven app auto-enable from service records (`uiRepo` / `uiRef` / `uiManifestUrl`)
-- Home app launcher cards for enabled capabilities
-- Appliances tab for gateway/NVR inventory, control-panel launch wiring, gateway installer utility download, and remote NVR service install requests
+- Appliances tab for gateway/service inventory, freshness, host relationship, installer utility download, and remote service install requests
+- Managed app launch direction for Pages-hosted first-party apps (for example `constitute-nvr-ui`)
 
 ## Project Layout
-- `app.js`: UI state, routing, and peer presentation
+- `app.js`: shell routes, appliances, launcher flow, and peer/service presentation
 - `identity/client.js`: window-to-Service Worker RPC bridge
 - `relay.worker.js`: shared relay transport worker
 - `identity/sw/*`: Service Worker daemon and protocol handlers
@@ -52,8 +53,8 @@ See `ARCHITECTURE.md` for system design and convergence direction.
 - In the installer utility, run release install/update for the current operator platform (service install only); first install prints a generated pairing code when pairing is pending
 - For paired gateways, use `Configure Zones` in appliance actions to sync identity zones plus gateway-specific extra zones
 - For paired Linux gateways, use `Install NVR Service` in appliance actions to trigger host-side NVR install remotely
-- Use `Settings > Appliances` to pair existing gateways and open NVR control panel surfaces
-- Manage optional app repos in `Settings > Apps` and launch enabled apps from Home
+- Use `Settings > Appliances` to pair existing gateways and launch owned managed app surfaces
+- Managed first-party apps publish separately under the site domain, for example `tld/constitute-nvr-ui/`
 - If identity/device prerequisites are missing, UI routes to onboarding
 
 ## Update Durability
@@ -63,10 +64,10 @@ See `ARCHITECTURE.md` for system design and convergence direction.
 - User state can still be lost by explicit browser site-data clearing; that is outside app control.
 
 ## Roadmap Snapshot
-- P0: converge web behavior to frozen gateway protocol contracts
-- P1: validate browser <-> gateway integration paths end-to-end
-- P2: browser swarm transport refinement (TURN as fallback boundary)
-- P3: codebase refactor and modularization
+- P0: service-backed device and managed app launch convergence
+- P1: validate gateway-mediated NVR launch and WebRTC live preview end to end
+- P2: browser swarm transport refinement and TURN hard-NAT fallback
+- P3: broader service/app surface expansion
 
 ## Security Notes
 - UI does not hold long-term secret material
@@ -75,4 +76,3 @@ See `ARCHITECTURE.md` for system design and convergence direction.
 
 ## License
 TBD
-

--- a/app.css
+++ b/app.css
@@ -310,6 +310,15 @@ button:disabled{opacity:0.5; cursor:not-allowed}
 .popoverTitle{font-weight:700; margin-bottom:0.5rem}
 .popoverTitle.small{font-weight:700; margin-bottom:0.35rem; font-size:.9rem}
 .popoverRow{display:flex; justify-content:space-between; font-size:0.9rem; margin:0.25rem 0}
+.popoverDetails{
+  display:flex;
+  flex-direction:column;
+  gap:0.18rem;
+  font-size:0.78rem;
+  margin:-0.05rem 0 0.45rem 0;
+  padding-left:0.1rem;
+  word-break:break-word;
+}
 
 /* Onboarding “radio” choice buttons */
 .choiceRow{

--- a/app.js
+++ b/app.js
@@ -275,6 +275,16 @@ class SwarmTransport {
       return;
     }
     const peers = this._selectPeers(list);
+    const peerSet = new Set(peers);
+    for (const pk of Array.from(this.channels.keys())) {
+      if (!peerSet.has(pk)) this._dropPeer(pk);
+    }
+    for (const pk of Array.from(this.peers.keys())) {
+      if (!peerSet.has(pk)) this._dropPeer(pk);
+    }
+    for (const pk of Array.from(this.connecting)) {
+      if (!peerSet.has(pk)) this.connecting.delete(pk);
+    }
     const key = peers.slice().sort().join(',');
     if (key === this.lastPeerKey) {
       this._updateState();
@@ -299,6 +309,16 @@ class SwarmTransport {
     if (openCount > 0) this.onState('open');
     else if (this.connecting.size > 0) this.onState('connecting');
     else this.onState('offline');
+  }
+
+  _dropPeer(pk) {
+    this.connecting.delete(pk);
+    const ch = this.channels.get(pk);
+    if (ch) try { ch.close(); } catch {}
+    this.channels.delete(pk);
+    const pc = this.peers.get(pk);
+    if (pc) try { pc.close(); } catch {}
+    this.peers.delete(pk);
   }
 
   async _connectTo(pk) {
@@ -430,6 +450,11 @@ class SwarmTransport {
 
   _selectPeers(list) {
     const arr = (Array.isArray(list) ? list : [])
+      .filter((rec) => {
+        const role = normalizeRole(rec?.role || rec?.nodeType || rec?.type || '');
+        const service = normalizeRole(rec?.service || '');
+        return role === 'browser' && !service;
+      })
       .map(r => String(r?.devicePk || '').trim())
       .filter(Boolean)
       .filter(pk => pk !== this.localPk);
@@ -1621,10 +1646,7 @@ async function launchNvrControlPanel(record) {
   }
 }
 
-function renderApplianceList(identityDevices, swarmDevices) {
-  if (!applianceList) return;
-  clear(applianceList);
-
+function buildApplianceRecords(identityDevices, swarmDevices) {
   const owned = ownedPkSet(identityDevices);
   const actual = [];
   const seen = new Set();
@@ -1636,7 +1658,6 @@ function renderApplianceList(identityDevices, swarmDevices) {
     const ownedRec = owned.has(pk) || owned.has(String(rec?.hostGatewayPk || rec?.host_gateway_pk || '').trim());
     const seenAt = applianceSeenAt(rec);
     const ageMs = seenAt ? Math.max(0, Date.now() - seenAt) : Number.POSITIVE_INFINITY;
-    // Keep owned appliances visible even if stale; hide very old unowned discovery rows.
     if (!ownedRec && ageMs > APPLIANCE_DISCOVERY_MAX_AGE_MS) continue;
     seen.add(pk);
     actual.push(rec);
@@ -1668,6 +1689,33 @@ function renderApplianceList(identityDevices, swarmDevices) {
     }
   }
 
+  recs.sort((a, b) => {
+    const aa = applianceSeenAt(a);
+    const bb = applianceSeenAt(b);
+    return Number(bb || 0) - Number(aa || 0);
+  });
+  return recs;
+}
+
+function findGatewayHostedServiceRecord(gatewayPk, applianceRecords, serviceName = 'nvr') {
+  const targetGatewayPk = String(gatewayPk || '').trim();
+  const targetService = normalizeRole(serviceName || '');
+  if (!targetGatewayPk || !targetService) return null;
+  const records = Array.isArray(applianceRecords) ? applianceRecords : [];
+  return records.find((rec) => {
+    const service = normalizeRole(rec?.service || '');
+    const hostGatewayPk = String(rec?.hostGatewayPk || rec?.host_gateway_pk || '').trim();
+    return service === targetService && hostGatewayPk === targetGatewayPk;
+  }) || null;
+}
+
+function renderApplianceList(identityDevices, swarmDevices) {
+  if (!applianceList) return;
+  clear(applianceList);
+
+  const owned = ownedPkSet(identityDevices);
+  const recs = buildApplianceRecords(identityDevices, swarmDevices);
+
   if (recs.length === 0) {
     const empty = document.createElement('div');
     empty.className = 'item';
@@ -1676,15 +1724,10 @@ function renderApplianceList(identityDevices, swarmDevices) {
     return;
   }
 
-  recs.sort((a, b) => {
-    const aa = applianceSeenAt(a);
-    const bb = applianceSeenAt(b);
-    return Number(bb || 0) - Number(aa || 0);
-  });
-
   for (const rec of recs) {
     const info = summarizeAppliance(rec, owned.has(String(rec?.devicePk || rec?.pk || '').trim()));
     const seenAt = applianceSeenAt(rec);
+    const hostedNvr = isGatewayRecord(rec) ? findGatewayHostedServiceRecord(info.pk, recs, 'nvr') : null;
 
     const item = document.createElement('div');
     item.className = 'item';
@@ -1767,10 +1810,16 @@ function renderApplianceList(identityDevices, swarmDevices) {
       if (gatewaySupportsServices) {
         const installNvr = document.createElement('button');
         installNvr.type = 'button';
-        installNvr.textContent = 'Install NVR Service';
+        installNvr.textContent = hostedNvr ? 'Open Security Cameras' : 'Install NVR Service';
         if (!info.owned) {
           installNvr.disabled = true;
           installNvr.title = 'Pair this gateway to your identity before installing services.';
+        } else if (hostedNvr) {
+          installNvr.onclick = () => {
+            launchNvrControlPanel(hostedNvr).catch((err) => {
+              setGatewayInstallStatus(`NVR launch failed: ${String(err?.message || err)}`, true);
+            });
+          };
         } else {
           installNvr.onclick = async () => {
             try {
@@ -2315,12 +2364,19 @@ function renderHomeApps() {
   if (!homeAppsList) return;
 
   const apps = enabledAppManifests().filter((app) => !isManagedFirstPartyApp(app));
-  if (!apps.length) {
+  const managedServices = buildApplianceRecords(lastIdentity?.devices || [], lastSwarmDevices)
+    .filter((rec) => isNvrRecord(rec))
+    .filter((rec) => {
+      const pk = String(rec?.devicePk || rec?.pk || '').trim();
+      const hostGatewayPk = String(rec?.hostGatewayPk || rec?.host_gateway_pk || '').trim();
+      const owned = ownedPkSet(lastIdentity?.devices || []);
+      return owned.has(pk) || owned.has(hostGatewayPk);
+    });
+  if (!apps.length && !managedServices.length) {
     const d = document.createElement('div');
     d.className = 'small muted';
-    d.textContent = 'No external apps enabled. Managed services launch from Appliances.';
+    d.textContent = 'No apps available yet. Install or pair a managed service from Appliances.';
     homeAppsList.appendChild(d);
-    return;
   }
 
   for (const app of apps) {
@@ -2349,6 +2405,42 @@ function renderHomeApps() {
     btn.textContent = 'Launch';
     btn.onclick = () => {
       launchAppWindow(app);
+    };
+
+    row.appendChild(left);
+    row.appendChild(btn);
+    homeAppsList.appendChild(row);
+  }
+
+  for (const rec of managedServices) {
+    const info = summarizeAppliance(rec, true);
+    const row = document.createElement('div');
+    row.className = 'item appItem';
+
+    const left = document.createElement('div');
+    left.className = 'appItemLabel';
+
+    const text = document.createElement('div');
+    const title = document.createElement('strong');
+    title.textContent = info.title || 'Security Cameras';
+
+    const meta = document.createElement('div');
+    meta.className = 'small muted';
+    const parts = ['Managed service', `service ${info.service || 'nvr'}`];
+    if (info.hostGatewayPk) parts.push(`gateway ${info.hostGatewayPk.slice(0, 12)}...`);
+    meta.textContent = parts.join(' - ');
+
+    text.appendChild(title);
+    text.appendChild(meta);
+    left.appendChild(text);
+
+    const btn = document.createElement('button');
+    btn.type = 'button';
+    btn.textContent = 'Open';
+    btn.onclick = () => {
+      launchNvrControlPanel(rec).catch((err) => {
+        setGatewayInstallStatus(`NVR launch failed: ${String(err?.message || err)}`, true);
+      });
     };
 
     row.appendChild(left);

--- a/app.js
+++ b/app.js
@@ -8,6 +8,7 @@ const connStateText = document.getElementById('connStateText');
 const connLog = document.getElementById('connLog');
 const connPopover = document.getElementById('connPopover');
 const popRelay = document.getElementById('popRelay');
+const popRelayDetails = document.getElementById('popRelayDetails');
 const popDaemon = document.getElementById('popDaemon');
 const popSwarm = document.getElementById('popSwarm');
 const popSwarmCache = document.getElementById('popSwarmCache');
@@ -110,6 +111,13 @@ const SWARM_ICE_SERVERS = [
   // { urls: 'turn:turn.example.com:3478', username: 'user', credential: 'pass' },
 ];
 
+const SHELL_BUILD_ID = '2026-04-03-relay-pool';
+const DEFAULT_PUBLIC_RELAYS = Object.freeze([
+  'wss://nos.lol',
+  'wss://relay.primal.net',
+  'wss://nostr.mom',
+]);
+
 let relayState = 'offline';
 let daemonState = 'unknown';
 let swarmState = 'offline';
@@ -143,6 +151,7 @@ const MANAGED_LAUNCH_STORAGE_PREFIX = 'constitute.launch.';
 const MANAGED_LAUNCH_TTL_MS = 2 * 60 * 1000;
 const MANAGED_APP_CHANNEL_NAME = 'constitute.app.launch';
 const GATEWAY_INVENTORY_REFRESH_TTL_MS = 15_000;
+const GATEWAY_HOSTED_SNAPSHOT_KEY = 'constitute.gatewayHostedSnapshots';
 const RELAY_BRIDGE_LEASE_KEY = 'constitute.relayBridge.owner';
 const RELAY_BRIDGE_LEASE_MS = 12_000;
 const RELAY_BRIDGE_HEARTBEAT_MS = 4_000;
@@ -170,6 +179,10 @@ const gatewayUtilityAssetUrlCache = new Map(); // asset -> { url, tag, prereleas
 let gatewayReleasesCache = null;
 let preparedGatewayInstall = null;
 const APPLIANCE_DISCOVERY_MAX_AGE_MS = 60 * 60 * 1000;
+
+let relayBridge = null;
+let relayPoolSnapshot = { version: '', urls: [], relays: {}, state: 'offline' };
+const gatewayHostedSnapshotCache = loadGatewayHostedSnapshotCache();
 
 function currentGatewayUtilityDownloadInfo() {
   const platform = currentOperatorPlatform();
@@ -661,9 +674,47 @@ function renderConnLog() {
   }
 }
 
-function setRelayState(s, reason = '') {
+function renderRelayDetails() {
+  if (!popRelayDetails) return;
+  const relayUrls = Array.isArray(relayPoolSnapshot?.urls) ? relayPoolSnapshot.urls : [];
+  const relays = relayPoolSnapshot?.relays && typeof relayPoolSnapshot.relays === 'object'
+    ? relayPoolSnapshot.relays
+    : {};
+  popRelayDetails.innerHTML = '';
+  const lines = [`shell ${SHELL_BUILD_ID}${relayPoolSnapshot?.version ? ` • relay ${relayPoolSnapshot.version}` : ''}`];
+  if (relayUrls.length > 0) lines.push(`targets ${relayUrls.length}: ${relayUrls.join(', ')}`);
+  for (const entry of lines) {
+    const line = document.createElement('div');
+    line.textContent = entry;
+    popRelayDetails.appendChild(line);
+  }
+  for (const relayUrl of relayUrls) {
+    const info = relays[relayUrl] || {};
+    const parts = [String(info.state || 'offline')];
+    if (info.code != null && info.code !== '') parts.push(`code=${info.code}`);
+    if (info.reason) parts.push(String(info.reason));
+    const line = document.createElement('div');
+    line.textContent = `${relayUrl} — ${parts.join(' • ')}`;
+    popRelayDetails.appendChild(line);
+  }
+}
+
+function setRelayState(s, reason = '', meta = null) {
   relayState = String(s || 'offline');
-  popRelay.textContent = relayState;
+  if (meta && typeof meta === 'object') {
+    relayPoolSnapshot = {
+      version: String(meta.version || relayPoolSnapshot.version || '').trim(),
+      urls: Array.isArray(meta.urls) ? meta.urls.slice() : (relayPoolSnapshot.urls || []),
+      relays: (meta.relays && typeof meta.relays === 'object') ? meta.relays : (relayPoolSnapshot.relays || {}),
+      state: relayState,
+    };
+  } else {
+    relayPoolSnapshot = { ...relayPoolSnapshot, state: relayState };
+  }
+  const relayUrls = Array.isArray(relayPoolSnapshot.urls) ? relayPoolSnapshot.urls : [];
+  const openCount = relayUrls.filter((relayUrl) => String(relayPoolSnapshot?.relays?.[relayUrl]?.state || '') === 'open').length;
+  popRelay.textContent = relayUrls.length > 0 ? `${relayState} (${openCount}/${relayUrls.length})` : relayState;
+  renderRelayDetails();
 
   _setConnDot();
   _pushConnLog(reason);
@@ -1656,7 +1707,8 @@ function buildApplianceRecords(identityDevices, swarmDevices) {
   const actual = [];
   const seen = new Set();
   const sourceRecords = Array.isArray(swarmDevices) ? swarmDevices : [];
-  for (const rec of sourceRecords) {
+  for (const rawRec of sourceRecords) {
+    const rec = applyGatewayHostedSnapshot(rawRec);
     const pk = String(rec?.devicePk || rec?.pk || '').trim();
     if (!pk || seen.has(pk)) continue;
     if (!(isGatewayRecord(rec) || isNvrRecord(rec))) continue;
@@ -1961,6 +2013,123 @@ function publishEnabledApps() {
 
 function normalizeRole(value) {
   return String(value || '').trim().toLowerCase();
+}
+
+function loadGatewayHostedSnapshotCache() {
+  try {
+    const raw = localStorage.getItem(GATEWAY_HOSTED_SNAPSHOT_KEY);
+    const parsed = raw ? JSON.parse(raw) : {};
+    return (parsed && typeof parsed === 'object') ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+function saveGatewayHostedSnapshotCache() {
+  try {
+    localStorage.setItem(GATEWAY_HOSTED_SNAPSHOT_KEY, JSON.stringify(gatewayHostedSnapshotCache));
+  } catch {}
+}
+
+function normalizeHostedServices(value) {
+  if (!Array.isArray(value)) return [];
+  return value
+    .map((entry) => (entry && typeof entry === 'object') ? entry : null)
+    .filter(Boolean);
+}
+
+function gatewayHostedSnapshot(record) {
+  const pk = String(record?.devicePk || record?.pk || '').trim();
+  const updatedAt = Number(record?.updatedAt || record?.updated_at || record?.ts || 0);
+  const hostedServices = normalizeHostedServices(record?.hostedServices || record?.hosted_services);
+  return { pk, updatedAt, hostedServices };
+}
+
+function applyGatewayHostedSnapshot(record) {
+  if (!isGatewayRecord(record)) return record;
+
+  const current = gatewayHostedSnapshot(record);
+  if (!current.pk) return record;
+
+  const cached = gatewayHostedSnapshotCache[current.pk] || null;
+  let effectiveHostedServices = current.hostedServices;
+
+  if (effectiveHostedServices.length > 0) {
+    gatewayHostedSnapshotCache[current.pk] = {
+      updatedAt: current.updatedAt,
+      hostedServices: effectiveHostedServices,
+    };
+    saveGatewayHostedSnapshotCache();
+  } else if (cached && Array.isArray(cached.hostedServices) && cached.hostedServices.length > 0) {
+    const cachedUpdatedAt = Number(cached.updatedAt || 0);
+    if (cachedUpdatedAt >= current.updatedAt) {
+      effectiveHostedServices = cached.hostedServices;
+    } else if (current.updatedAt >= cachedUpdatedAt) {
+      gatewayHostedSnapshotCache[current.pk] = {
+        updatedAt: current.updatedAt,
+        hostedServices: [],
+      };
+      saveGatewayHostedSnapshotCache();
+    }
+  }
+
+  if (effectiveHostedServices === current.hostedServices) return record;
+  return {
+    ...record,
+    hostedServices: effectiveHostedServices,
+  };
+}
+
+function pageAllowsInsecureRelayUrls() {
+  try {
+    const u = new URL(window.location.href);
+    return u.protocol === 'http:' || u.hostname === 'localhost' || u.hostname === '127.0.0.1';
+  } catch {
+    return false;
+  }
+}
+
+function normalizeRelayCandidate(url) {
+  const raw = String(url || '').trim();
+  if (!raw) return '';
+  let parsed;
+  try {
+    parsed = new URL(raw);
+  } catch {
+    return '';
+  }
+  if (parsed.protocol !== 'ws:' && parsed.protocol !== 'wss:') return '';
+  if (parsed.protocol === 'ws:' && !pageAllowsInsecureRelayUrls()) return '';
+  const host = String(parsed.hostname || '').trim().toLowerCase();
+  if (!host || host === 'gateway.example' || host.includes('replace-host') || host.endsWith('.example')) return '';
+  parsed.hash = '';
+  return parsed.toString();
+}
+
+function collectOwnedGatewayRelayUrls(identityDevices, swarmDevices) {
+  const owned = ownedPkSet(identityDevices);
+  const out = [];
+  for (const rec of (Array.isArray(swarmDevices) ? swarmDevices : [])) {
+    if (!isGatewayRecord(rec)) continue;
+    const pk = String(rec?.devicePk || rec?.pk || '').trim();
+    if (!pk || !owned.has(pk)) continue;
+    const relays = Array.isArray(rec?.relays) ? rec.relays : [];
+    for (const relayUrl of relays) {
+      const normalized = normalizeRelayCandidate(relayUrl);
+      if (normalized && !out.includes(normalized)) out.push(normalized);
+    }
+  }
+  return out;
+}
+
+function desiredRelayUrls(identityDevices = [], swarmDevices = []) {
+  const candidates = [...DEFAULT_PUBLIC_RELAYS, ...collectOwnedGatewayRelayUrls(identityDevices, swarmDevices)];
+  const out = [];
+  for (const relayUrl of candidates) {
+    const normalized = normalizeRelayCandidate(relayUrl);
+    if (normalized && !out.includes(normalized)) out.push(normalized);
+  }
+  return out;
 }
 
 function repoKey(owner, repo) {
@@ -3005,6 +3174,7 @@ async function refreshAll() {
   lastDirectory = directory || [];
   lastZones = zones || [];
   lastSwarmDevices = swarmDevices || [];
+  relayBridge?.updateTargets(desiredRelayUrls(ident?.devices || [], lastSwarmDevices), 'refresh');
 
   // If we only have a key, try to resolve the human name via peers.
   for (const z of (lastZones || [])) {
@@ -3426,13 +3596,14 @@ function wireUi() {
   };
 }
 
-function startSharedRelayPipe(client, relayUrl) {
+function startSharedRelayPipe(client, initialRelayUrls) {
   const w = new SharedWorker('./relay.worker.js');
   const port = w.port;
   port.start();
   const ownerId = randomOpaqueId('relay-bridge');
   let relayBridgeOwner = false;
   let heartbeatTimer = null;
+  let targetKey = '';
 
   function readRelayBridgeLease() {
     try {
@@ -3486,6 +3657,16 @@ function startSharedRelayPipe(client, relayUrl) {
     });
   }
 
+  function updateTargets(urls, reason = 'update') {
+    const targets = Array.isArray(urls) ? urls.filter(Boolean) : [];
+    const nextKey = targets.join('\n');
+    if (nextKey === targetKey) return false;
+    targetKey = nextKey;
+    console.info('[relay.bridge] targets', reason, targets);
+    port.postMessage({ type: 'relay.connect', urls: targets });
+    return true;
+  }
+
   port.onmessage = async (ev) => {
     const msg = ev.data || {};
     if (msg.type === 'relay.status') {
@@ -3493,11 +3674,29 @@ function startSharedRelayPipe(client, relayUrl) {
       if (msg.state === 'error' || msg.state === 'closed') {
         console.warn('[relay.worker]', msg.state, reason || '(no reason)');
       }
-      setRelayState(msg.state, reason);
+      const relayUrls = Array.isArray(msg.urls) ? msg.urls : (msg.url ? [msg.url] : []);
+      const relayDetails = (msg.relays && typeof msg.relays === 'object')
+        ? msg.relays
+        : ((msg.url || '')
+          ? {
+              [msg.url]: {
+                state: msg.state,
+                code: msg.code ?? null,
+                reason: msg.reason ?? '',
+              },
+            }
+          : {});
+      setRelayState(msg.state, reason, {
+        version: String(msg.version || '').trim(),
+        urls: relayUrls,
+        relays: relayDetails,
+      });
       if (clientReady && relayBridgeOwner) {
         client.call('relay.status', {
           state: msg.state,
           url: msg.url || '',
+          urls: relayUrls,
+          relays: relayDetails,
           code: msg.code ?? null,
           reason: msg.reason ?? ''
         }, { timeoutMs: 20000, priority: 'immediate' }).catch((e) => console.error('relay.status rpc failed', e));
@@ -3521,8 +3720,8 @@ function startSharedRelayPipe(client, relayUrl) {
   });
 
   startRelayBridgeHeartbeat();
-  port.postMessage({ type: 'relay.connect', url: relayUrl });
-  return port;
+  updateTargets(initialRelayUrls, 'init');
+  return { port, updateTargets };
 }
 
 (async function main() {
@@ -3570,8 +3769,9 @@ function startSharedRelayPipe(client, relayUrl) {
 
   await client.ready().catch((e) => console.error(e));
   clientReady = client.isServiceWorkerAvailable();
+  console.info('[shell.build]', SHELL_BUILD_ID, window.location.href);
   if (clientReady) {
-    startSharedRelayPipe(client, 'wss://relay.snort.social');
+    relayBridge = startSharedRelayPipe(client, desiredRelayUrls([], []));
   } else {
     setDaemonState('offline', 'sw unavailable');
   }

--- a/app.js
+++ b/app.js
@@ -155,6 +155,7 @@ const GATEWAY_HOSTED_SNAPSHOT_KEY = 'constitute.gatewayHostedSnapshots';
 const RELAY_BRIDGE_LEASE_KEY = 'constitute.relayBridge.owner';
 const RELAY_BRIDGE_LEASE_MS = 12_000;
 const RELAY_BRIDGE_HEARTBEAT_MS = 4_000;
+const RELAY_WORKER_QUIET_TIMEOUT_MS = 1_500;
 
 const NVR_INSTALLERS = Object.freeze({
   linux: {
@@ -843,6 +844,21 @@ function randomOpaqueId(prefix = 'id') {
   crypto.getRandomValues(bytes);
   const token = Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('');
   return `${prefix}-${token}`;
+}
+
+function relayWorkerScriptUrl() {
+  const url = new URL('./relay.worker.js', window.location.href);
+  url.searchParams.set('v', SHELL_BUILD_ID);
+  return url.toString();
+}
+
+function browserPrefersDedicatedRelayWorker() {
+  try {
+    const ua = String(navigator.userAgent || '');
+    return typeof SharedWorker === 'undefined' || /\bFirefox\//.test(ua);
+  } catch {
+    return typeof SharedWorker === 'undefined';
+  }
 }
 
 function managedLaunchStorageKey(launchId) {
@@ -3597,13 +3613,32 @@ function wireUi() {
 }
 
 function startSharedRelayPipe(client, initialRelayUrls) {
-  const w = new SharedWorker('./relay.worker.js');
-  const port = w.port;
-  port.start();
   const ownerId = randomOpaqueId('relay-bridge');
   let relayBridgeOwner = false;
   let heartbeatTimer = null;
   let targetKey = '';
+  let relayRuntime = null;
+  let workerQuietTimer = null;
+  let lastRelayRuntimeMessageAt = 0;
+
+  function clearWorkerQuietTimer() {
+    if (!workerQuietTimer) return;
+    clearTimeout(workerQuietTimer);
+    workerQuietTimer = null;
+  }
+
+  function teardownRelayRuntime(reason = '') {
+    clearWorkerQuietTimer();
+    if (!relayRuntime) return;
+    try {
+      relayRuntime.postMessage?.({ type: 'relay.close' });
+    } catch {}
+    try {
+      relayRuntime.close?.();
+    } catch {}
+    relayRuntime = null;
+    if (reason) console.info('[relay.bridge] runtime closed', reason);
+  }
 
   function readRelayBridgeLease() {
     try {
@@ -3657,18 +3692,8 @@ function startSharedRelayPipe(client, initialRelayUrls) {
     });
   }
 
-  function updateTargets(urls, reason = 'update') {
-    const targets = Array.isArray(urls) ? urls.filter(Boolean) : [];
-    const nextKey = targets.join('\n');
-    if (nextKey === targetKey) return false;
-    targetKey = nextKey;
-    console.info('[relay.bridge] targets', reason, targets);
-    port.postMessage({ type: 'relay.connect', urls: targets });
-    return true;
-  }
-
-  port.onmessage = async (ev) => {
-    const msg = ev.data || {};
+  function handleRelayRuntimeMessage(msg) {
+    lastRelayRuntimeMessageAt = Date.now();
     if (msg.type === 'relay.status') {
       const reason = [msg.reason || '', msg.code != null ? `code=${msg.code}` : ''].filter(Boolean).join(' ');
       if (msg.state === 'error' || msg.state === 'closed') {
@@ -3708,20 +3733,94 @@ function startSharedRelayPipe(client, initialRelayUrls) {
         client.call('relay.rx', { data: msg.data, url: msg.url || '' }, { timeoutMs: 20000, priority: 'immediate' })
           .catch((e) => console.error('relay.rx rpc failed', e));
       }
-      return;
     }
-  };
+  }
+
+  function scheduleQuietFallback() {
+    clearWorkerQuietTimer();
+    workerQuietTimer = setTimeout(() => {
+      if (!relayRuntime || relayRuntime.mode !== 'shared') return;
+      if (lastRelayRuntimeMessageAt > 0) return;
+      console.warn('[relay.bridge] shared worker quiet; falling back to dedicated runtime');
+      startRelayRuntime('shared-timeout');
+      if (targetKey) {
+        relayRuntime?.postMessage?.({ type: 'relay.connect', urls: targetKey.split('\n').filter(Boolean) });
+      }
+    }, RELAY_WORKER_QUIET_TIMEOUT_MS);
+  }
+
+  function createSharedRelayRuntime() {
+    const scriptUrl = relayWorkerScriptUrl();
+    const worker = new SharedWorker(scriptUrl);
+    const port = worker.port;
+    port.start();
+    port.onmessage = (ev) => handleRelayRuntimeMessage(ev.data || {});
+    port.onmessageerror = (ev) => console.error('[relay.bridge] shared worker messageerror', ev);
+    return {
+      mode: 'shared',
+      scriptUrl,
+      postMessage: (msg) => port.postMessage(msg),
+      close: () => {
+        try { port.onmessage = null; } catch {}
+        try { port.postMessage({ type: 'relay.close' }); } catch {}
+      },
+    };
+  }
+
+  function createDedicatedRelayRuntime() {
+    const scriptUrl = relayWorkerScriptUrl();
+    const worker = new Worker(scriptUrl);
+    worker.onmessage = (ev) => handleRelayRuntimeMessage(ev.data || {});
+    worker.onerror = (ev) => console.error('[relay.bridge] dedicated worker error', ev?.message || ev);
+    worker.onmessageerror = (ev) => console.error('[relay.bridge] dedicated worker messageerror', ev);
+    return {
+      mode: 'dedicated',
+      scriptUrl,
+      postMessage: (msg) => worker.postMessage(msg),
+      close: () => worker.terminate(),
+    };
+  }
+
+  function startRelayRuntime(reason = 'init') {
+    teardownRelayRuntime(`restart:${reason}`);
+    lastRelayRuntimeMessageAt = 0;
+    const preferDedicated = browserPrefersDedicatedRelayWorker();
+    try {
+      relayRuntime = preferDedicated ? createDedicatedRelayRuntime() : createSharedRelayRuntime();
+    } catch (err) {
+      console.warn('[relay.bridge] shared worker unavailable; using dedicated runtime', err);
+      relayRuntime = createDedicatedRelayRuntime();
+    }
+    console.info('[relay.bridge] runtime', relayRuntime.mode, reason, relayRuntime.scriptUrl);
+    if (relayRuntime.mode === 'shared') scheduleQuietFallback();
+    relayRuntime.postMessage({ type: 'relay.status' });
+    return relayRuntime;
+  }
+
+  function updateTargets(urls, reason = 'update') {
+    const targets = Array.isArray(urls) ? urls.filter(Boolean) : [];
+    const nextKey = targets.join('\n');
+    if (nextKey === targetKey) return false;
+    targetKey = nextKey;
+    console.info('[relay.bridge] targets', reason, targets);
+    relayRuntime?.postMessage?.({ type: 'relay.connect', urls: targets });
+    return true;
+  }
 
   navigator.serviceWorker.addEventListener('message', (e) => {
     const m = e.data || {};
     if (relayBridgeOwner && m.type === 'relay.tx' && typeof m.data === 'string') {
-      port.postMessage({ type: 'relay.send', frame: m.data });
+      relayRuntime?.postMessage?.({ type: 'relay.send', frame: m.data });
     }
   });
 
   startRelayBridgeHeartbeat();
+  startRelayRuntime('init');
   updateTargets(initialRelayUrls, 'init');
-  return { port, updateTargets };
+  return {
+    updateTargets,
+    close: () => teardownRelayRuntime('api-close'),
+  };
 }
 
 (async function main() {

--- a/app.js
+++ b/app.js
@@ -143,6 +143,9 @@ const MANAGED_LAUNCH_STORAGE_PREFIX = 'constitute.launch.';
 const MANAGED_LAUNCH_TTL_MS = 2 * 60 * 1000;
 const MANAGED_APP_CHANNEL_NAME = 'constitute.app.launch';
 const GATEWAY_INVENTORY_REFRESH_TTL_MS = 15_000;
+const RELAY_BRIDGE_LEASE_KEY = 'constitute.relayBridge.owner';
+const RELAY_BRIDGE_LEASE_MS = 12_000;
+const RELAY_BRIDGE_HEARTBEAT_MS = 4_000;
 
 const NVR_INSTALLERS = Object.freeze({
   linux: {
@@ -3397,6 +3400,61 @@ function startSharedRelayPipe(client, relayUrl) {
   const w = new SharedWorker('./relay.worker.js');
   const port = w.port;
   port.start();
+  const ownerId = randomOpaqueId('relay-bridge');
+  let relayBridgeOwner = false;
+  let heartbeatTimer = null;
+
+  function readRelayBridgeLease() {
+    try {
+      const raw = localStorage.getItem(RELAY_BRIDGE_LEASE_KEY);
+      const parsed = raw ? JSON.parse(raw) : null;
+      return parsed && typeof parsed === 'object' ? parsed : null;
+    } catch {
+      return null;
+    }
+  }
+
+  function writeRelayBridgeLease() {
+    const next = {
+      ownerId,
+      expiresAt: Date.now() + RELAY_BRIDGE_LEASE_MS,
+    };
+    try {
+      localStorage.setItem(RELAY_BRIDGE_LEASE_KEY, JSON.stringify(next));
+    } catch {}
+    return next;
+  }
+
+  function updateRelayBridgeOwner(reason = '') {
+    const lease = readRelayBridgeLease();
+    const now = Date.now();
+    const shouldOwn = !lease || Number(lease.expiresAt || 0) <= now || lease.ownerId === ownerId;
+    if (shouldOwn) writeRelayBridgeLease();
+    const nextOwner = shouldOwn;
+    if (nextOwner !== relayBridgeOwner) {
+      relayBridgeOwner = nextOwner;
+      console.info('[relay.bridge]', relayBridgeOwner ? 'owner' : 'follower', reason || '');
+    }
+    return relayBridgeOwner;
+  }
+
+  function startRelayBridgeHeartbeat() {
+    updateRelayBridgeOwner('init');
+    heartbeatTimer = setInterval(() => {
+      updateRelayBridgeOwner('heartbeat');
+    }, RELAY_BRIDGE_HEARTBEAT_MS);
+    window.addEventListener('storage', (ev) => {
+      if (ev.key === RELAY_BRIDGE_LEASE_KEY) updateRelayBridgeOwner('storage');
+    });
+    window.addEventListener('beforeunload', () => {
+      clearInterval(heartbeatTimer);
+      if (!relayBridgeOwner) return;
+      const lease = readRelayBridgeLease();
+      if (lease?.ownerId === ownerId) {
+        try { localStorage.removeItem(RELAY_BRIDGE_LEASE_KEY); } catch {}
+      }
+    });
+  }
 
   port.onmessage = async (ev) => {
     const msg = ev.data || {};
@@ -3406,7 +3464,7 @@ function startSharedRelayPipe(client, relayUrl) {
         console.warn('[relay.worker]', msg.state, reason || '(no reason)');
       }
       setRelayState(msg.state, reason);
-      if (clientReady) {
+      if (clientReady && relayBridgeOwner) {
         client.call('relay.status', {
           state: msg.state,
           url: msg.url || '',
@@ -3417,7 +3475,7 @@ function startSharedRelayPipe(client, relayUrl) {
       return;
     }
     if (msg.type === 'relay.rx' && typeof msg.data === 'string') {
-      if (clientReady) {
+      if (clientReady && relayBridgeOwner) {
         client.call('relay.rx', { data: msg.data, url: msg.url || '' }, { timeoutMs: 20000 })
           .catch((e) => console.error('relay.rx rpc failed', e));
       }
@@ -3427,11 +3485,12 @@ function startSharedRelayPipe(client, relayUrl) {
 
   navigator.serviceWorker.addEventListener('message', (e) => {
     const m = e.data || {};
-    if (m.type === 'relay.tx' && typeof m.data === 'string') {
+    if (relayBridgeOwner && m.type === 'relay.tx' && typeof m.data === 'string') {
       port.postMessage({ type: 'relay.send', frame: m.data });
     }
   });
 
+  startRelayBridgeHeartbeat();
   port.postMessage({ type: 'relay.connect', url: relayUrl });
   return port;
 }

--- a/app.js
+++ b/app.js
@@ -142,6 +142,7 @@ const MANAGED_APP_SURFACES = Object.freeze({
 const MANAGED_LAUNCH_STORAGE_PREFIX = 'constitute.launch.';
 const MANAGED_LAUNCH_TTL_MS = 2 * 60 * 1000;
 const MANAGED_APP_CHANNEL_NAME = 'constitute.app.launch';
+const GATEWAY_INVENTORY_REFRESH_TTL_MS = 15_000;
 
 const NVR_INSTALLERS = Object.freeze({
   linux: {
@@ -237,6 +238,7 @@ async function resolveGatewayUtilityAssetUrl(assetName) {
 }
 
 let lastSwarmDevices = [];
+const gatewayInventoryRefreshAt = new Map();
 const pendingGatewayServiceInstalls = new Map();
 const pendingGatewayZoneSyncs = new Map();
 const pendingManagedLaunches = new Map();
@@ -1709,6 +1711,30 @@ function findGatewayHostedServiceRecord(gatewayPk, applianceRecords, serviceName
   }) || null;
 }
 
+function shouldRefreshGatewayInventory(gatewayPk) {
+  const pk = String(gatewayPk || '').trim();
+  if (!pk) return false;
+  const lastAt = Number(gatewayInventoryRefreshAt.get(pk) || 0);
+  return (Date.now() - lastAt) >= GATEWAY_INVENTORY_REFRESH_TTL_MS;
+}
+
+async function requestGatewayInventoryRefresh(gatewayPk) {
+  const pk = String(gatewayPk || '').trim();
+  if (!pk || !shouldRefreshGatewayInventory(pk)) return false;
+  gatewayInventoryRefreshAt.set(pk, Date.now());
+  console.info('[managed] requesting fresh gateway inventory', pk);
+  try {
+    await client.call('swarm.record.request', {
+      want: ['device'],
+      devicePk: pk,
+    }, { timeoutMs: 20_000 });
+    return true;
+  } catch (err) {
+    console.warn('[managed] gateway inventory request failed', pk, err);
+    return false;
+  }
+}
+
 function renderApplianceList(identityDevices, swarmDevices) {
   if (!applianceList) return;
   clear(applianceList);
@@ -2978,9 +3004,20 @@ async function refreshAll() {
   renderZones(lastZones);
   renderPeers(lastDirectory);
   renderApplianceList(ident?.devices || [], lastSwarmDevices);
+  renderHomeApps();
   renderPairRequests(reqs || [], ident?.devices || []);
   renderNotifications(notifs || []);
   ensureOnboardingState(ident);
+  const applianceRecords = buildApplianceRecords(ident?.devices || [], lastSwarmDevices);
+  const ownedGatewayPksNeedingRefresh = applianceRecords
+    .filter((rec) => isGatewayRecord(rec))
+    .map((rec) => summarizeAppliance(rec, ownedPkSet(ident?.devices || []).has(String(rec?.devicePk || rec?.pk || '').trim())))
+    .filter((info) => info.owned)
+    .filter((info) => !findGatewayHostedServiceRecord(info.pk, applianceRecords, 'nvr'))
+    .map((info) => info.pk);
+  for (const gatewayPk of ownedGatewayPksNeedingRefresh) {
+    requestGatewayInventoryRefresh(gatewayPk).catch(() => {});
+  }
   await autoEnableAppsForIdentityDeviceRoles(ident?.devices || [], swarmDevices || []).catch(() => {});
   if (swarm && ident?.linked) {
     swarm.setLocalPk(st.pk || '');
@@ -3364,7 +3401,11 @@ function startSharedRelayPipe(client, relayUrl) {
   port.onmessage = async (ev) => {
     const msg = ev.data || {};
     if (msg.type === 'relay.status') {
-      setRelayState(msg.state, msg.reason || '');
+      const reason = [msg.reason || '', msg.code != null ? `code=${msg.code}` : ''].filter(Boolean).join(' ');
+      if (msg.state === 'error' || msg.state === 'closed') {
+        console.warn('[relay.worker]', msg.state, reason || '(no reason)');
+      }
+      setRelayState(msg.state, reason);
       if (clientReady) {
         client.call('relay.status', {
           state: msg.state,

--- a/app.js
+++ b/app.js
@@ -129,17 +129,19 @@ let swarmBootRequested = false;
 const APPS_REPOS_KEY = 'constitute.apps.repos';
 const APPS_ENABLED_KEY = 'constitute.apps.enabled';
 const GATEWAY_EXTRA_ZONES_KEY = 'constitute.gateway.extraZones';
-const DEFAULT_APP_REPOS = ['https://github.com/Aux0x7F/constitute-nvr-ui'];
-const ROLE_APP_REPO_MAP = Object.freeze({
-  nvr: ['https://github.com/Aux0x7F/constitute-nvr-ui'],
-});
-const SERVICE_APP_REPO_MAP = Object.freeze({
-  nvr: ['https://github.com/Aux0x7F/constitute-nvr-ui'],
-});
+const DEFAULT_APP_REPOS = [];
+const ROLE_APP_REPO_MAP = Object.freeze({});
+const SERVICE_APP_REPO_MAP = Object.freeze({});
 let appRepoCatalog = [];
 let appEnabledIds = new Set();
 let appLaunchHints = new Map();
 window.__constituteEnabledApps = [];
+const MANAGED_APP_SURFACES = Object.freeze({
+  nvr: 'constitute-nvr-ui',
+});
+const MANAGED_LAUNCH_STORAGE_PREFIX = 'constitute.launch.';
+const MANAGED_LAUNCH_TTL_MS = 2 * 60 * 1000;
+const MANAGED_APP_CHANNEL_NAME = 'constitute.app.launch';
 
 const NVR_INSTALLERS = Object.freeze({
   linux: {
@@ -237,7 +239,10 @@ async function resolveGatewayUtilityAssetUrl(assetName) {
 let lastSwarmDevices = [];
 const pendingGatewayServiceInstalls = new Map();
 const pendingGatewayZoneSyncs = new Map();
+const pendingManagedLaunches = new Map();
+const pendingGatewaySignals = new Map();
 let gatewayExtraZonesByPk = {};
+let managedAppChannel = null;
 
 class SwarmTransport {
   constructor({ client, onState }) {
@@ -752,6 +757,188 @@ function setGatewayInstallCommandPreview(msg = '') {
   gatewayInstallCommandPreview.textContent = String(msg || '');
 }
 
+function randomOpaqueId(prefix = 'id') {
+  const bytes = new Uint8Array(12);
+  crypto.getRandomValues(bytes);
+  const token = Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('');
+  return `${prefix}-${token}`;
+}
+
+function managedLaunchStorageKey(launchId) {
+  return `${MANAGED_LAUNCH_STORAGE_PREFIX}${String(launchId || '').trim()}`;
+}
+
+function cleanupManagedLaunchContexts() {
+  try {
+    const now = Date.now();
+    const keys = [];
+    for (let i = 0; i < localStorage.length; i += 1) {
+      const key = localStorage.key(i);
+      if (key && key.startsWith(MANAGED_LAUNCH_STORAGE_PREFIX)) keys.push(key);
+    }
+    for (const key of keys) {
+      try {
+        const raw = localStorage.getItem(key);
+        const parsed = raw ? JSON.parse(raw) : null;
+        const expiresAt = Number(parsed?.expiresAt || parsed?.createdAt || 0);
+        if (!parsed || !expiresAt || expiresAt < now) {
+          localStorage.removeItem(key);
+        }
+      } catch {
+        localStorage.removeItem(key);
+      }
+    }
+  } catch {}
+}
+
+function readManagedLaunchContext(launchId) {
+  const id = String(launchId || '').trim();
+  if (!id) return null;
+  cleanupManagedLaunchContexts();
+  try {
+    const raw = localStorage.getItem(managedLaunchStorageKey(id));
+    if (!raw) return null;
+    const parsed = JSON.parse(raw);
+    const expiresAt = Number(parsed?.expiresAt || 0);
+    if (expiresAt && expiresAt < Date.now()) {
+      localStorage.removeItem(managedLaunchStorageKey(id));
+      return null;
+    }
+    return parsed && typeof parsed === 'object' ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function writeManagedLaunchContext(context) {
+  const launchId = String(context?.launchId || '').trim();
+  if (!launchId) throw new Error('launch context missing launchId');
+  cleanupManagedLaunchContexts();
+  const payload = {
+    ...context,
+    createdAt: Number(context?.createdAt || Date.now()),
+    expiresAt: Number(context?.expiresAt || (Date.now() + MANAGED_LAUNCH_TTL_MS)),
+  };
+  localStorage.setItem(managedLaunchStorageKey(launchId), JSON.stringify(payload));
+  return payload;
+}
+
+function buildManagedAppSurfaceUrl(repoName, launchId) {
+  const repo = String(repoName || '').trim();
+  if (!repo) throw new Error('missing managed app repo');
+  const target = new URL(window.location.origin);
+  target.pathname = `/${repo}/`;
+  target.hash = `launch=${encodeURIComponent(String(launchId || '').trim())}`;
+  return target.toString();
+}
+
+function settlePending(map, requestId, error, result) {
+  const key = String(requestId || '').trim();
+  if (!key) return false;
+  const pending = map.get(key);
+  if (!pending) return false;
+  clearTimeout(pending.timer);
+  map.delete(key);
+  if (error) pending.reject(error);
+  else pending.resolve(result);
+  return true;
+}
+
+function createPendingRequest(map, requestId, label, timeoutMs = 20_000) {
+  const key = String(requestId || '').trim();
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      map.delete(key);
+      reject(new Error(`${label} timed out`));
+    }, timeoutMs);
+    map.set(key, { resolve, reject, timer, createdAt: Date.now() });
+  });
+}
+
+function managedAppSurfaceRepoForService(service) {
+  const key = normalizeRole(service || '');
+  return MANAGED_APP_SURFACES[key] || '';
+}
+
+function isManagedFirstPartyApp(app) {
+  const repo = String(app?.repo || '').trim().toLowerCase();
+  return Object.values(MANAGED_APP_SURFACES).some((value) => value.toLowerCase() === repo);
+}
+
+function ensureManagedAppChannel() {
+  if (managedAppChannel || typeof BroadcastChannel === 'undefined') return managedAppChannel;
+  managedAppChannel = new BroadcastChannel(MANAGED_APP_CHANNEL_NAME);
+  managedAppChannel.onmessage = (event) => {
+    handleManagedAppChannelMessage(event?.data || {}).catch((err) => {
+      console.error('managed app channel message failed', err);
+    });
+  };
+  return managedAppChannel;
+}
+
+async function handleManagedAppChannelMessage(message) {
+  const type = String(message?.type || '').trim();
+  const channel = ensureManagedAppChannel();
+  if (!type || !channel) return;
+
+  if (type === 'launch-context.request') {
+    const launchId = String(message?.launchId || '').trim();
+    if (!launchId) return;
+    const context = readManagedLaunchContext(launchId);
+    channel.postMessage({
+      type: 'launch-context.response',
+      launchId,
+      ok: !!context,
+      context,
+      error: context ? '' : 'launch context unavailable',
+    });
+    return;
+  }
+
+  if (type === 'gateway.signal.request') {
+    const requestId = String(message?.requestId || '').trim() || randomOpaqueId('gw-signal-ui');
+    const launchId = String(message?.launchId || '').trim();
+    const context = readManagedLaunchContext(launchId);
+    if (!context) {
+      channel.postMessage({
+        type: 'gateway.signal.response',
+        launchId,
+        requestId,
+        ok: false,
+        error: 'launch context unavailable',
+      });
+      return;
+    }
+
+    try {
+      const result = await requestGatewaySignal({
+        requestId,
+        gatewayPk: context.gatewayPk,
+        servicePk: context.servicePk,
+        service: context.service || 'nvr',
+        launchToken: context.launchToken,
+        signalType: String(message?.signalType || '').trim(),
+        payload: message?.payload ?? {},
+      });
+      channel.postMessage({
+        type: 'gateway.signal.response',
+        launchId,
+        requestId,
+        ok: true,
+        result,
+      });
+    } catch (err) {
+      channel.postMessage({
+        type: 'gateway.signal.response',
+        launchId,
+        requestId,
+        ok: false,
+        error: String(err?.message || err),
+      });
+    }
+  }
+}
+
 function summarizeInstallDetail(detail) {
   const raw = String(detail || '').trim();
   if (!raw) return '';
@@ -808,6 +995,64 @@ function handleGatewayZoneSyncStatusEvent(evt) {
   if (status === 'complete') {
     refreshAll().catch(() => {});
   }
+}
+
+function handleGatewayManagedLaunchStatusEvent(evt) {
+  const requestId = String(evt?.requestId || '').trim();
+  const status = String(evt?.status || '').trim().toLowerCase();
+  if (!requestId) return;
+
+  if (status === 'complete') {
+    settlePending(pendingManagedLaunches, requestId, null, {
+      requestId,
+      gatewayPk: String(evt?.gatewayPk || '').trim(),
+      servicePk: String(evt?.servicePk || '').trim(),
+      service: String(evt?.service || '').trim(),
+      capability: String(evt?.capability || '').trim(),
+      launchToken: String(evt?.launchToken || '').trim(),
+      expiresAt: Number(evt?.expiresAt || 0),
+      display: evt?.display ?? {},
+      ts: Number(evt?.ts || Date.now()),
+    });
+    return;
+  }
+
+  if (status === 'failed' || status === 'rejected') {
+    const detail = String(evt?.detail || evt?.reason || 'managed launch failed').trim();
+    settlePending(pendingManagedLaunches, requestId, new Error(detail || 'managed launch failed'));
+  }
+}
+
+function handleGatewaySignalStatusRelayEvent(evt) {
+  const requestId = String(evt?.requestId || '').trim();
+  const status = String(evt?.status || '').trim().toLowerCase();
+  if (!requestId) return;
+  if (status === 'failed' || status === 'rejected') {
+    const detail = String(evt?.detail || evt?.reason || 'gateway signal failed').trim();
+    settlePending(pendingGatewaySignals, requestId, new Error(detail || 'gateway signal failed'));
+    return;
+  }
+  if (status === 'complete' && String(evt?.signalType || '').trim().toLowerCase() === 'session_close') {
+    settlePending(pendingGatewaySignals, requestId, null, {
+      requestId,
+      signalType: 'session_close',
+      ts: Number(evt?.ts || Date.now()),
+    });
+  }
+}
+
+function handleGatewaySignalRelayEvent(evt) {
+  const requestId = String(evt?.requestId || '').trim();
+  if (!requestId) return;
+  settlePending(pendingGatewaySignals, requestId, null, {
+    requestId,
+    gatewayPk: String(evt?.gatewayPk || '').trim(),
+    servicePk: String(evt?.servicePk || '').trim(),
+    service: String(evt?.service || '').trim(),
+    signalType: String(evt?.signalType || '').trim(),
+    payload: evt?.payload ?? {},
+    ts: Number(evt?.ts || Date.now()),
+  });
 }
 
 function detectOperatorPlatform() {
@@ -1148,6 +1393,7 @@ function applianceSeenAt(rec) {
 function summarizeAppliance(rec, owned) {
   const pk = String(rec?.devicePk || rec?.pk || '').trim();
   const label = String(rec?.deviceLabel || rec?.label || '').trim();
+  const deviceKind = normalizeRole(rec?.deviceKind || rec?.device_kind || '') || 'user';
   const role = normalizeRole(rec?.role || rec?.nodeType || rec?.type || '') || 'unknown';
   const service = normalizeRole(rec?.service || '') || 'none';
   const version = String(rec?.serviceVersion || rec?.service_version || '').trim();
@@ -1155,10 +1401,15 @@ function summarizeAppliance(rec, owned) {
   const releaseChannel = String(rec?.releaseChannel || rec?.release_channel || '').trim();
   const releaseTrack = String(rec?.releaseTrack || rec?.release_track || '').trim();
   const releaseBranch = String(rec?.releaseBranch || rec?.release_branch || '').trim();
+  const hostGatewayPk = String(rec?.hostGatewayPk || rec?.host_gateway_pk || '').trim();
+  const hostedServices = Array.isArray(rec?.hostedServices || rec?.hosted_services)
+    ? (rec.hostedServices || rec.hosted_services)
+    : [];
   const updatedAt = Number(rec?.updatedAt || rec?.updated_at || rec?.ts || rec?.lastSeen || 0);
   return {
     pk,
     title: label || `${role}:${pk.slice(0, 12)}`,
+    deviceKind,
     role,
     service,
     version,
@@ -1166,6 +1417,8 @@ function summarizeAppliance(rec, owned) {
     releaseChannel,
     releaseTrack,
     releaseBranch,
+    hostGatewayPk,
+    hostedServices,
     updatedAt,
     owned,
   };
@@ -1238,6 +1491,71 @@ async function ensureNvrAppEnabledFromRecord(record) {
   ) || null;
 }
 
+function managedGatewayPkForRecord(record) {
+  const gatewayPk = String(record?.hostGatewayPk || record?.host_gateway_pk || '').trim();
+  if (gatewayPk) return gatewayPk;
+  if (isGatewayRecord(record)) return String(record?.devicePk || record?.pk || '').trim();
+  return '';
+}
+
+function managedServicePkForRecord(record) {
+  return String(record?.devicePk || record?.pk || '').trim();
+}
+
+async function requestGatewayManagedLaunch(record, opts = {}) {
+  const gatewayPk = managedGatewayPkForRecord(record);
+  const servicePk = managedServicePkForRecord(record);
+  const service = String(opts?.service || record?.service || 'nvr').trim() || 'nvr';
+  const capability = String(opts?.capability || `${service}.view`).trim() || `${service}.view`;
+  if (!gatewayPk) throw new Error('host gateway is not known for this service yet');
+  if (!servicePk) throw new Error('service public key is missing');
+  if (!String(lastIdentity?.id || '').trim()) throw new Error('link an identity before opening managed services');
+  if (!String(lastDeviceState?.pk || '').trim()) throw new Error('device key is not ready yet');
+
+  const requestId = randomOpaqueId('gw-launch');
+  const pending = createPendingRequest(pendingManagedLaunches, requestId, 'managed launch', 20_000);
+  try {
+    await client.call('gateway.managedLaunch.request', {
+      requestId,
+      gatewayPk,
+      servicePk,
+      service,
+      capability,
+      appRepo: managedAppSurfaceRepoForService(service),
+      display: {
+        shell: 'constitute',
+        surface: managedAppSurfaceRepoForService(service),
+      },
+    }, { timeoutMs: 20_000 });
+  } catch (err) {
+    settlePending(pendingManagedLaunches, requestId, err);
+    throw err;
+  }
+  return await pending;
+}
+
+async function requestGatewaySignal(req) {
+  const requestId = String(req?.requestId || '').trim() || randomOpaqueId('gw-signal');
+  const signalType = String(req?.signalType || '').trim().toLowerCase();
+  if (!signalType) throw new Error('missing signal type');
+  const pending = createPendingRequest(pendingGatewaySignals, requestId, `gateway ${signalType}`, 30_000);
+  try {
+    await client.call('gateway.signal.request', {
+      requestId,
+      gatewayPk: String(req?.gatewayPk || '').trim(),
+      servicePk: String(req?.servicePk || '').trim(),
+      service: String(req?.service || 'nvr').trim() || 'nvr',
+      signalType,
+      payload: req?.payload ?? {},
+      launchToken: String(req?.launchToken || '').trim(),
+    }, { timeoutMs: 20_000 });
+  } catch (err) {
+    settlePending(pendingGatewaySignals, requestId, err);
+    throw err;
+  }
+  return await pending;
+}
+
 function launchAppWindow(app) {
   const base = appLaunchUrl(app);
   if (!base) {
@@ -1258,15 +1576,48 @@ function launchAppWindow(app) {
 }
 
 async function launchNvrControlPanel(record) {
+  let popup = null;
   try {
-    const app = await ensureNvrAppEnabledFromRecord(record);
-    if (!app) {
-      setGatewayInstallStatus('NVR UI manifest unavailable for this device.', true);
-      return;
+    popup = window.open('', '_blank');
+    if (popup && !popup.closed) {
+      popup.document.title = 'Launching Security Cameras';
+      popup.document.body.innerHTML = '<pre style="font:14px/1.5 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; padding:16px; color:#dce3ea; background:#0b1220;">Launching Security Cameras…</pre>';
     }
-    launchAppWindow(app);
+
+    const launch = await requestGatewayManagedLaunch(record, {
+      service: 'nvr',
+      capability: 'nvr.view',
+    });
+
+    const launchId = randomOpaqueId('launch');
+    const context = writeManagedLaunchContext({
+      launchId,
+      app: 'nvr',
+      repo: managedAppSurfaceRepoForService('nvr'),
+      identityId: String(lastIdentity?.id || '').trim(),
+      devicePk: String(lastDeviceState?.pk || '').trim(),
+      gatewayPk: String(launch?.gatewayPk || managedGatewayPkForRecord(record) || '').trim(),
+      servicePk: String(launch?.servicePk || managedServicePkForRecord(record) || '').trim(),
+      service: 'nvr',
+      launchToken: String(launch?.launchToken || '').trim(),
+      display: launch?.display ?? {},
+      createdAt: Date.now(),
+      expiresAt: Number(launch?.expiresAt || (Date.now() + MANAGED_LAUNCH_TTL_MS)),
+    });
+
+    const url = buildManagedAppSurfaceUrl(managedAppSurfaceRepoForService('nvr'), launchId);
+    if (popup && !popup.closed) {
+      popup.location.replace(url);
+    } else {
+      window.open(url, '_blank', 'noopener,noreferrer');
+    }
+    setGatewayInstallStatus('Opened Security Cameras.', false);
   } catch (err) {
     setGatewayInstallStatus(`NVR control panel failed: ${String(err?.message || err)}`, true);
+    if (popup && !popup.closed) {
+      popup.document.title = 'Security Cameras Launch Failed';
+      popup.document.body.innerHTML = `<pre style="font:14px/1.5 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; padding:16px; color:#fca5a5; background:#0b1220;">Launch failed: ${escapeHtml(String(err?.message || err))}</pre>`;
+    }
   }
 }
 
@@ -1275,19 +1626,46 @@ function renderApplianceList(identityDevices, swarmDevices) {
   clear(applianceList);
 
   const owned = ownedPkSet(identityDevices);
-  const recs = [];
+  const actual = [];
   const seen = new Set();
-  for (const rec of (Array.isArray(swarmDevices) ? swarmDevices : [])) {
+  const sourceRecords = Array.isArray(swarmDevices) ? swarmDevices : [];
+  for (const rec of sourceRecords) {
     const pk = String(rec?.devicePk || rec?.pk || '').trim();
     if (!pk || seen.has(pk)) continue;
     if (!(isGatewayRecord(rec) || isNvrRecord(rec))) continue;
-    const ownedRec = owned.has(pk);
+    const ownedRec = owned.has(pk) || owned.has(String(rec?.hostGatewayPk || rec?.host_gateway_pk || '').trim());
     const seenAt = applianceSeenAt(rec);
     const ageMs = seenAt ? Math.max(0, Date.now() - seenAt) : Number.POSITIVE_INFINITY;
     // Keep owned appliances visible even if stale; hide very old unowned discovery rows.
     if (!ownedRec && ageMs > APPLIANCE_DISCOVERY_MAX_AGE_MS) continue;
     seen.add(pk);
-    recs.push(rec);
+    actual.push(rec);
+  }
+
+  const recs = [...actual];
+  const actualPkSet = new Set(actual.map((rec) => String(rec?.devicePk || rec?.pk || '').trim()).filter(Boolean));
+  for (const rec of actual) {
+    if (!isGatewayRecord(rec)) continue;
+    const hostedServices = Array.isArray(rec?.hostedServices || rec?.hosted_services)
+      ? (rec.hostedServices || rec.hosted_services)
+      : [];
+    for (const hosted of hostedServices) {
+      const pk = String(hosted?.devicePk || hosted?.device_pk || '').trim();
+      if (!pk || actualPkSet.has(pk)) continue;
+      recs.push({
+        devicePk: pk,
+        deviceLabel: String(hosted?.deviceLabel || hosted?.device_label || hosted?.service || 'service').trim(),
+        deviceKind: String(hosted?.deviceKind || hosted?.device_kind || 'service').trim() || 'service',
+        role: String(hosted?.service || '').trim(),
+        service: String(hosted?.service || '').trim(),
+        hostGatewayPk: String(hosted?.hostGatewayPk || hosted?.host_gateway_pk || rec?.devicePk || rec?.pk || '').trim(),
+        serviceVersion: String(hosted?.serviceVersion || hosted?.service_version || '').trim(),
+        updatedAt: Number(hosted?.updatedAt || hosted?.updated_at || rec?.updatedAt || 0),
+        freshnessMs: Number(hosted?.freshnessMs || hosted?.freshness_ms || 0),
+        hostedSynthetic: true,
+      });
+      actualPkSet.add(pk);
+    }
   }
 
   if (recs.length === 0) {
@@ -1316,12 +1694,21 @@ function renderApplianceList(identityDevices, swarmDevices) {
     const last = seenAt ? new Date(seenAt).toLocaleString() : 'n/a';
     const suffix = info.version ? ` (${info.version})` : '';
     const host = info.hostPlatform ? ` • host ${info.hostPlatform}` : '';
+    const kind = info.deviceKind ? `type ${info.deviceKind}` : '';
     const releaseMeta = formatReleaseMeta(info.releaseChannel, info.releaseTrack, info.releaseBranch);
     const releaseLine = releaseMeta ? `<div class="itemMeta">release ${escapeHtml(releaseMeta)}</div>` : '';
+    const hostGatewayLine = info.hostGatewayPk
+      ? `<div class="itemMeta">host gateway ${escapeHtml(info.hostGatewayPk.slice(0, 16))}…</div>`
+      : '';
+    const hostedServicesLine = Array.isArray(info.hostedServices) && info.hostedServices.length > 0
+      ? `<div class="itemMeta">hosted services ${escapeHtml(info.hostedServices.map((svc) => String(svc?.service || 'service')).join(', '))}</div>`
+      : '';
     meta.innerHTML = `
       <div class="itemTitle">${escapeHtml(info.title)}</div>
       <div class="itemMeta">pk ${escapeHtml(info.pk.slice(0, 16))}…</div>
-      <div class="itemMeta">role ${escapeHtml(info.role)} • service ${escapeHtml(info.service)}${escapeHtml(suffix)}${escapeHtml(host)}</div>
+      <div class="itemMeta">${escapeHtml([kind, `role ${info.role}`, `service ${info.service}${suffix}`, host ? host.replace(/^ • /, '') : ''].filter(Boolean).join(' • '))}</div>
+      ${hostGatewayLine}
+      ${hostedServicesLine}
       ${releaseLine}
       <div class="itemMeta"><span class="freshnessDot ${escapeHtml(freshness.css)}" title="${escapeHtml(last)}"></span>${escapeHtml(freshness.label)} • ${escapeHtml(formatAgeShort(seenAt))}</div>
       <div class="itemMeta">${info.owned ? 'owned by this identity' : 'discovered in zone'} • updated ${escapeHtml(last)}</div>
@@ -1422,11 +1809,16 @@ function renderApplianceList(identityDevices, swarmDevices) {
       const open = document.createElement('button');
       open.type = 'button';
       open.textContent = 'Open Security Cameras';
-      open.onclick = () => {
-        launchNvrControlPanel(rec).catch((err) => {
-          setGatewayInstallStatus(`NVR launch failed: ${String(err?.message || err)}`, true);
-        });
-      };
+      if (!info.owned) {
+        open.disabled = true;
+        open.title = 'Only services owned by this identity can be launched.';
+      } else {
+        open.onclick = () => {
+          launchNvrControlPanel(rec).catch((err) => {
+            setGatewayInstallStatus(`NVR launch failed: ${String(err?.message || err)}`, true);
+          });
+        };
+      }
       actions.appendChild(open);
     }
 
@@ -1922,11 +2314,11 @@ function renderHomeApps() {
   clear(homeAppsList);
   if (!homeAppsList) return;
 
-  const apps = enabledAppManifests();
+  const apps = enabledAppManifests().filter((app) => !isManagedFirstPartyApp(app));
   if (!apps.length) {
     const d = document.createElement('div');
     d.className = 'small muted';
-    d.textContent = 'No apps enabled.';
+    d.textContent = 'No external apps enabled. Managed services launch from Appliances.';
     homeAppsList.appendChild(d);
     return;
   }
@@ -2941,6 +3333,15 @@ function startSharedRelayPipe(client, relayUrl) {
       if (evt?.type === 'gateway_zone_sync_status') {
         handleGatewayZoneSyncStatusEvent(evt);
       }
+      if (evt?.type === 'gateway_managed_launch_status') {
+        handleGatewayManagedLaunchStatusEvent(evt);
+      }
+      if (evt?.type === 'gateway_signal_status') {
+        handleGatewaySignalStatusRelayEvent(evt);
+      }
+      if (evt?.type === 'gateway_signal') {
+        handleGatewaySignalRelayEvent(evt);
+      }
       if (evt?.type === 'notify') refreshAll().catch(() => {});
     }
   });
@@ -2964,6 +3365,8 @@ function startSharedRelayPipe(client, relayUrl) {
   }
 
   loadGatewayExtraZones();
+  cleanupManagedLaunchContexts();
+  ensureManagedAppChannel();
   wireUi();
   await hydrateAppCatalog();
   _pushConnLog('init');

--- a/app.js
+++ b/app.js
@@ -2945,6 +2945,36 @@ btnSecWebAuthn?.addEventListener('click', () => setSecurityChoice('webauthn'));
 btnSecSkip?.addEventListener('click', () => setSecurityChoice('skip'));
 
 let client;
+let refreshAllInflight = null;
+let refreshAllQueued = false;
+let refreshAllTimer = null;
+
+async function runRefreshAll() {
+  if (refreshAllInflight) {
+    refreshAllQueued = true;
+    return await refreshAllInflight;
+  }
+  refreshAllInflight = (async () => {
+    try {
+      await refreshAll();
+    } finally {
+      refreshAllInflight = null;
+      if (refreshAllQueued) {
+        refreshAllQueued = false;
+        runRefreshAll().catch(() => {});
+      }
+    }
+  })();
+  return await refreshAllInflight;
+}
+
+function scheduleRefreshAll(delayMs = 150) {
+  clearTimeout(refreshAllTimer);
+  refreshAllTimer = setTimeout(() => {
+    refreshAllTimer = null;
+    runRefreshAll().catch(() => {});
+  }, delayMs);
+}
 
 function ensureOnboardingState(ident) {
   if (!ident?.linked) {
@@ -3470,13 +3500,13 @@ function startSharedRelayPipe(client, relayUrl) {
           url: msg.url || '',
           code: msg.code ?? null,
           reason: msg.reason ?? ''
-        }, { timeoutMs: 20000 }).catch((e) => console.error('relay.status rpc failed', e));
+        }, { timeoutMs: 20000, priority: 'immediate' }).catch((e) => console.error('relay.status rpc failed', e));
       }
       return;
     }
     if (msg.type === 'relay.rx' && typeof msg.data === 'string') {
       if (clientReady && relayBridgeOwner) {
-        client.call('relay.rx', { data: msg.data, url: msg.url || '' }, { timeoutMs: 20000 })
+        client.call('relay.rx', { data: msg.data, url: msg.url || '' }, { timeoutMs: 20000, priority: 'immediate' })
           .catch((e) => console.error('relay.rx rpc failed', e));
       }
       return;
@@ -3534,7 +3564,7 @@ function startSharedRelayPipe(client, relayUrl) {
       if (evt?.type === 'gateway_signal') {
         handleGatewaySignalRelayEvent(evt);
       }
-      if (evt?.type === 'notify') refreshAll().catch(() => {});
+      if (evt?.type === 'notify') scheduleRefreshAll();
     }
   });
 
@@ -3567,7 +3597,7 @@ function startSharedRelayPipe(client, relayUrl) {
   setSecurityChoice('webauthn');
 
   try {
-    await refreshAll();
+    await runRefreshAll();
     const linked = await ensureOnboardingFlow();
     if (linked) {
       setSettingsTab('profile');

--- a/identity/client.js
+++ b/identity/client.js
@@ -19,7 +19,9 @@ export class IdentityClient {
     if ("serviceWorker" in navigator) {
       navigator.serviceWorker.addEventListener("message", (e) => this._onMessage(e));
       navigator.serviceWorker.addEventListener("controllerchange", () => {
-        this.onEvent({ type: "log", message: "service worker controllerchange" });
+        const controller = navigator.serviceWorker.controller;
+        const scriptUrl = String(controller?.scriptURL || this._reg?.active?.scriptURL || '').trim();
+        this.onEvent({ type: "log", message: `service worker controllerchange ${scriptUrl || '(unknown script)'}` });
       });
     }
   }
@@ -47,6 +49,10 @@ export class IdentityClient {
       }
 
       this._reg = reg;
+      const activeScriptUrl = String(reg?.active?.scriptURL || reg?.waiting?.scriptURL || reg?.installing?.scriptURL || '').trim();
+      if (activeScriptUrl) {
+        console.log("[client] service worker registration", activeScriptUrl);
+      }
       console.log("[client] waiting for SW ready");
       await Promise.race([
         navigator.serviceWorker.ready,

--- a/identity/client.js
+++ b/identity/client.js
@@ -84,7 +84,11 @@ export class IdentityClient {
   /**
    * Enqueue an RPC call (serialized).
    */
-  call(method, params = {}, { timeoutMs } = {}) {
+  call(method, params = {}, { timeoutMs, priority } = {}) {
+    if (priority === 'immediate') {
+      return this._callOnce(method, params, { timeoutMs });
+    }
+
     const run = () => this._callOnce(method, params, { timeoutMs });
 
     const p = this._queue.then(run);

--- a/identity/sw/daemon.js
+++ b/identity/sw/daemon.js
@@ -40,7 +40,8 @@ export function startDaemon(sw) {
   (async () => {
     await ensureDevice();
     const ident = await getIdentity();
-    log(sw, `boot ok (linked=${!!ident?.linked})`);
+    const buildId = String(globalThis.__CONSTITUTE_SW_BUILD_ID__ || '').trim();
+    log(sw, `boot ok (linked=${!!ident?.linked})${buildId ? ` build=${buildId}` : ''}`);
     pokeUi(sw);
   })();
 }

--- a/identity/sw/relayIn.js
+++ b/identity/sw/relayIn.js
@@ -841,6 +841,68 @@ export async function handleRelayFrame(sw, raw) {
     return;
   }
 
+  if (payload.type === 'gateway_managed_launch_status') {
+    const toDevicePk = String(payload.toDevicePk || '').trim();
+    if (toDevicePk && toDevicePk !== String(dev?.nostr?.pk || '').trim()) return;
+    emit(sw, {
+      type: 'gateway_managed_launch_status',
+      requestId: String(payload.requestId || '').trim(),
+      status: String(payload.status || '').trim(),
+      gatewayPk: String(payload.gatewayPk || '').trim(),
+      toDevicePk,
+      identityId: String(payload.identityId || '').trim(),
+      devicePk: String(payload.devicePk || '').trim(),
+      servicePk: String(payload.servicePk || '').trim(),
+      service: String(payload.service || '').trim(),
+      capability: String(payload.capability || '').trim(),
+      launchToken: String(payload.launchToken || '').trim(),
+      expiresAt: Number(payload.expiresAt || 0),
+      display: payload.display ?? null,
+      reason: String(payload.reason || '').trim(),
+      detail: String(payload.detail || '').trim(),
+      ts: Number(payload.ts || Date.now()),
+    });
+    return;
+  }
+
+  if (payload.type === 'gateway_signal_status') {
+    const devicePk = String(payload.devicePk || '').trim();
+    if (devicePk && devicePk !== String(dev?.nostr?.pk || '').trim()) return;
+    emit(sw, {
+      type: 'gateway_signal_status',
+      requestId: String(payload.requestId || '').trim(),
+      status: String(payload.status || '').trim(),
+      gatewayPk: String(payload.gatewayPk || '').trim(),
+      identityId: String(payload.identityId || '').trim(),
+      devicePk,
+      servicePk: String(payload.servicePk || '').trim(),
+      service: String(payload.service || '').trim(),
+      signalType: String(payload.signalType || '').trim(),
+      reason: String(payload.reason || '').trim(),
+      detail: String(payload.detail || '').trim(),
+      ts: Number(payload.ts || Date.now()),
+    });
+    return;
+  }
+
+  if (payload.type === 'gateway_signal') {
+    const devicePk = String(payload.devicePk || '').trim();
+    if (devicePk && devicePk !== String(dev?.nostr?.pk || '').trim()) return;
+    emit(sw, {
+      type: 'gateway_signal',
+      requestId: String(payload.requestId || '').trim(),
+      gatewayPk: String(payload.gatewayPk || '').trim(),
+      identityId: String(payload.identityId || '').trim(),
+      devicePk,
+      servicePk: String(payload.servicePk || '').trim(),
+      service: String(payload.service || '').trim(),
+      signalType: String(payload.signalType || '').trim(),
+      payload: payload.payload ?? null,
+      ts: Number(payload.ts || Date.now()),
+    });
+    return;
+  }
+
   // --- Swarm signal (WebRTC signaling) ---
   if (payload.type === 'swarm_signal') {
     const to = String(payload.to || '').trim();

--- a/identity/sw/relayIn.js
+++ b/identity/sw/relayIn.js
@@ -208,8 +208,17 @@ export async function handleRelayFrame(sw, raw) {
     if (recType === 'device') {
       const ok = await validateRecord(ev, 'device');
       if (!ok) return;
-      await putDeviceRecord(ev).catch(() => {});
-      log(sw, 'swarm device record stored');
+      const discoveryPayload = (() => {
+        try { return JSON.parse(ev.content || '{}'); } catch { return {}; }
+      })();
+      const result = await putDeviceRecord(ev).catch(() => ({ ok: false }));
+      if (!result?.ok) return;
+      if (result?.stale) {
+        log(sw, 'swarm device record stale (ignored)');
+        return;
+      }
+      const hostedCount = Array.isArray(discoveryPayload?.hostedServices) ? discoveryPayload.hostedServices.length : 0;
+      log(sw, hostedCount > 0 ? `swarm device record stored hosted=${hostedCount}` : 'swarm device record stored');
       pokeUi(sw);
       return;
     }

--- a/identity/sw/rpc.js
+++ b/identity/sw/rpc.js
@@ -622,6 +622,75 @@ export async function handleRpc(sw, method, params, getRelayState, setRelayState
     return { ok: true, requestId, targetGatewayPk, zoneKeys, extraZoneKeys };
   }
 
+  if (method === 'gateway.managedLaunch.request') {
+    const ident = await getIdentity();
+    if (!ident?.linked || !ident?.id || !ident?.label) throw new Error('no linked identity');
+
+    const dev = await ensureDevice();
+    const targetGatewayPk = String(params?.gatewayPk || params?.gatewayDevicePk || params?.toDevicePk || '').trim();
+    const servicePk = String(params?.servicePk || '').trim();
+    const service = String(params?.service || 'nvr').trim() || 'nvr';
+    const capability = String(params?.capability || `${service}.view`).trim() || `${service}.view`;
+    if (!targetGatewayPk) throw new Error('missing gatewayPk');
+    if (!servicePk) throw new Error('missing servicePk');
+
+    const requestId = String(params?.requestId || '').trim() || makeSwarmRequestId('gw-launch');
+    const payload = {
+      type: 'gateway_managed_launch_request',
+      requestId,
+      toDevicePk: targetGatewayPk,
+      identityId: String(ident.id || '').trim(),
+      devicePk: String(dev?.nostr?.pk || '').trim(),
+      servicePk,
+      service,
+      capability,
+      appRepo: String(params?.appRepo || '').trim(),
+      display: params?.display && typeof params.display === 'object' ? params.display : {},
+      ts: Date.now(),
+      ttl: 120,
+    };
+
+    const zones = await listZones(ident || {}).catch(() => []);
+    await publishAppEvent(sw, payload, pairingTags(ident.label, zones, targetGatewayPk));
+    return { ok: true, requestId, gatewayPk: targetGatewayPk, servicePk, service, capability };
+  }
+
+  if (method === 'gateway.signal.request') {
+    const ident = await getIdentity();
+    if (!ident?.linked || !ident?.id || !ident?.label) throw new Error('no linked identity');
+
+    const dev = await ensureDevice();
+    const targetGatewayPk = String(params?.gatewayPk || params?.gatewayDevicePk || params?.toDevicePk || '').trim();
+    const servicePk = String(params?.servicePk || '').trim();
+    const service = String(params?.service || 'nvr').trim() || 'nvr';
+    const signalType = String(params?.signalType || '').trim().toLowerCase();
+    const launchToken = String(params?.launchToken || '').trim();
+    if (!targetGatewayPk) throw new Error('missing gatewayPk');
+    if (!servicePk) throw new Error('missing servicePk');
+    if (!signalType) throw new Error('missing signalType');
+    if (!launchToken) throw new Error('missing launchToken');
+
+    const requestId = String(params?.requestId || '').trim() || makeSwarmRequestId('gw-signal');
+    const payload = {
+      type: 'gateway_signal_request',
+      requestId,
+      toDevicePk: targetGatewayPk,
+      identityId: String(ident.id || '').trim(),
+      devicePk: String(dev?.nostr?.pk || '').trim(),
+      servicePk,
+      service,
+      signalType,
+      payload: params?.payload ?? {},
+      launchToken,
+      ts: Date.now(),
+      ttl: 120,
+    };
+
+    const zones = await listZones(ident || {}).catch(() => []);
+    await publishAppEvent(sw, payload, pairingTags(ident.label, zones, targetGatewayPk));
+    return { ok: true, requestId, gatewayPk: targetGatewayPk, servicePk, service, signalType };
+  }
+
   if (method === 'identity.create') {
     // REQUIRED: must not already have a linked identity on this device
     const existing = await getIdentity();

--- a/identity/sw/rpc.js
+++ b/identity/sw/rpc.js
@@ -897,11 +897,12 @@ export async function handleRpc(sw, method, params, getRelayState, setRelayState
   if (method === 'relay.status') {
     const state = String(params?.state || '');
     const url = String(params?.url || '');
-    if (state && state !== getRelayState()) {
+    const prevState = String(getRelayState() || '');
+    if (state && state !== prevState) {
       setRelayState(state);
       log(sw, `relay state -> ${state} ${url}`);
     }
-    if (state === 'open') {
+    if (state === 'open' && prevState !== 'open') {
       const ident = await getIdentity();
       const dev = await ensureDevice();
       await subOpen(sw, ident, (m) => log(sw, m));

--- a/identity/sw/swarm/discovery.js
+++ b/identity/sw/swarm/discovery.js
@@ -54,6 +54,27 @@ function parseContent(ev) {
   try { return JSON.parse(ev?.content || ''); } catch { return null; }
 }
 
+function recordFreshnessTuple(ev, payload) {
+  const p = payload || parseContent(ev) || {};
+  const updatedAt = Number(p?.updatedAt || 0);
+  const expiresAt = Number(p?.expiresAt || 0);
+  const createdAt = Number(ev?.created_at || 0);
+  return [updatedAt, createdAt, expiresAt];
+}
+
+function isIncomingRecordNewer(currentEv, incomingEv) {
+  if (!currentEv) return true;
+  const currentPayload = parseContent(currentEv) || {};
+  const incomingPayload = parseContent(incomingEv) || {};
+  const currentTuple = recordFreshnessTuple(currentEv, currentPayload);
+  const incomingTuple = recordFreshnessTuple(incomingEv, incomingPayload);
+  for (let i = 0; i < incomingTuple.length; i += 1) {
+    if (incomingTuple[i] > currentTuple[i]) return true;
+    if (incomingTuple[i] < currentTuple[i]) return false;
+  }
+  return false;
+}
+
 function clockOk(createdAt) {
   const now = nowSec();
   if (!createdAt) return false;
@@ -145,7 +166,10 @@ export async function putIdentityRecord(ev) {
   const ok = await validateRecord(ev, 'identity');
   if (!ok) return { ok: false };
   const payload = parseContent(ev);
-  await kvSet(recordKey('identity', payload.identityId), ev);
+  const key = recordKey('identity', payload.identityId);
+  const current = await kvGet(key);
+  if (!isIncomingRecordNewer(current, ev)) return { ok: true, stale: true };
+  await kvSet(key, ev);
   await addToIndex(ID_INDEX_KEY, payload.identityId);
   return { ok: true };
 }
@@ -154,7 +178,10 @@ export async function putDeviceRecord(ev) {
   const ok = await validateRecord(ev, 'device');
   if (!ok) return { ok: false };
   const payload = parseContent(ev);
-  await kvSet(recordKey('device', payload.devicePk), ev);
+  const key = recordKey('device', payload.devicePk);
+  const current = await kvGet(key);
+  if (!isIncomingRecordNewer(current, ev)) return { ok: true, stale: true };
+  await kvSet(key, ev);
   await addToIndex(DEV_INDEX_KEY, payload.devicePk);
   return { ok: true };
 }
@@ -164,7 +191,10 @@ export async function putDhtRecord(ev) {
   if (!ok) return { ok: false };
   const payload = parseContent(ev);
   const id = dhtIndexId(payload.scope, payload.key);
-  await kvSet(recordKey('dht', id), ev);
+  const key = recordKey('dht', id);
+  const current = await kvGet(key);
+  if (!isIncomingRecordNewer(current, ev)) return { ok: true, stale: true };
+  await kvSet(key, ev);
   await addToIndex(DHT_INDEX_KEY, id);
   return { ok: true };
 }

--- a/index.html
+++ b/index.html
@@ -21,6 +21,7 @@
           <div id="connPopover" class="popover hidden" role="status" aria-live="polite">
             <div class="popoverTitle">Status</div>
             <div class="popoverRow"><span class="muted">Relay</span><span id="popRelay">offline</span></div>
+            <div id="popRelayDetails" class="popoverDetails muted"></div>
             <div class="popoverRow"><span class="muted">Identity</span><span id="popDaemon">unknown</span></div>
             <div class="popoverRow"><span class="muted">Swarm</span><span id="popSwarm">offline</span></div>
             <div class="popoverRow"><span class="muted">Swarm cache</span><span id="popSwarmCache">n/a</span></div>

--- a/relay.worker.js
+++ b/relay.worker.js
@@ -2,6 +2,16 @@ let ws = null;
 let wsUrl = null;
 let state = 'idle';
 const ports = new Set();
+let reconnectTimer = null;
+let reconnectAttempt = 0;
+let manualClose = false;
+
+function clearReconnectTimer() {
+  if (reconnectTimer) {
+    clearTimeout(reconnectTimer);
+    reconnectTimer = null;
+  }
+}
 
 function broadcast(msg) {
   for (const p of ports) {
@@ -14,9 +24,23 @@ function setState(next, extra = {}) {
   broadcast({ type: 'relay.status', state, url: wsUrl || '', ...extra });
 }
 
-function connect(url) {
+function scheduleReconnect() {
+  clearReconnectTimer();
+  if (manualClose || !wsUrl) return;
+  reconnectAttempt += 1;
+  const delayMs = Math.min(15_000, 1_000 * Math.max(1, reconnectAttempt));
+  setState('connecting', { reason: `reconnect in ${delayMs}ms`, attempt: reconnectAttempt });
+  reconnectTimer = setTimeout(() => {
+    reconnectTimer = null;
+    connect(wsUrl, { isRetry: true });
+  }, delayMs);
+}
+
+function connect(url, { isRetry = false } = {}) {
   const target = String(url || '').trim();
   if (!target) throw new Error('missing url');
+  manualClose = false;
+  clearReconnectTimer();
 
   if (ws && wsUrl === target && ws.readyState === WebSocket.OPEN) {
     setState('open');
@@ -27,15 +51,19 @@ function connect(url) {
   ws = null;
 
   wsUrl = target;
-  setState('connecting');
+  setState('connecting', isRetry ? { reason: `retry ${reconnectAttempt}` } : {});
 
   ws = new WebSocket(wsUrl);
 
-  ws.onopen = () => setState('open');
+  ws.onopen = () => {
+    reconnectAttempt = 0;
+    setState('open');
+  };
   ws.onerror = () => setState('error');
   ws.onclose = (e) => {
     setState('closed', { code: e?.code ?? null, reason: e?.reason ?? '' });
     ws = null;
+    scheduleReconnect();
   };
 
   ws.onmessage = (e) => {
@@ -70,6 +98,8 @@ onconnect = (e) => {
         return;
       }
       if (msg.type === 'relay.close') {
+        manualClose = true;
+        clearReconnectTimer();
         try { if (ws) ws.close(); } catch {}
         ws = null;
         setState('closed');

--- a/relay.worker.js
+++ b/relay.worker.js
@@ -1,15 +1,21 @@
 const RELAY_WORKER_BUILD_ID = '2026-04-03-relay-pool';
 const MAX_RECENT_EVENT_IDS = 2048;
 
-const ports = new Set();
+const endpoints = new Set();
 const relays = new Map();
 const recentEventIds = new Map();
 let desiredRelayUrls = [];
+let dedicatedEndpoint = null;
+
+function endpointPost(endpoint, msg) {
+  try {
+    if (endpoint.kind === 'shared') endpoint.port.postMessage(msg);
+    else self.postMessage(msg);
+  } catch {}
+}
 
 function broadcast(msg) {
-  for (const port of ports) {
-    try { port.postMessage(msg); } catch {}
-  }
+  for (const endpoint of endpoints) endpointPost(endpoint, msg);
 }
 
 function currentRelayUrls() {
@@ -33,7 +39,9 @@ function aggregateRelayState() {
   if (relays.size === 0) return { state: 'offline', code: null, reason: 'no relays configured' };
   const snapshot = Array.from(relays.values());
   if (snapshot.some((relay) => relay.state === 'open')) return { state: 'open', code: null, reason: '' };
-  if (snapshot.some((relay) => relay.state === 'connecting')) return { state: 'connecting', code: null, reason: 'waiting for relay open' };
+  if (snapshot.some((relay) => relay.state === 'connecting')) {
+    return { state: 'connecting', code: null, reason: 'waiting for relay open' };
+  }
   const firstFailure = snapshot.find((relay) => relay.code != null || relay.reason);
   return {
     state: 'error',
@@ -80,8 +88,7 @@ function extractEventId(frame) {
     const parsed = JSON.parse(String(frame || ''));
     if (!Array.isArray(parsed) || parsed[0] !== 'EVENT') return '';
     const event = parsed.length >= 3 ? parsed[2] : parsed[1];
-    const id = event && typeof event === 'object' ? String(event.id || '').trim() : '';
-    return id;
+    return event && typeof event === 'object' ? String(event.id || '').trim() : '';
   } catch {
     return '';
   }
@@ -200,51 +207,49 @@ function send(frame) {
   if (!sent) throw new Error('relay not open');
 }
 
-onconnect = (event) => {
-  const port = event.ports[0];
-  ports.add(port);
-
-  port.onmessage = (messageEvent) => {
-    const msg = messageEvent.data || {};
-    try {
-      if (msg.type === 'relay.connect') {
-        const urls = Array.isArray(msg.urls) ? msg.urls : (msg.url ? [msg.url] : []);
-        updateRelayTargets(urls);
-        port.postMessage({ type: 'relay.ack', ok: true });
-        return;
-      }
-      if (msg.type === 'relay.send') {
-        send(msg.frame);
-        port.postMessage({ type: 'relay.ack', ok: true });
-        return;
-      }
-      if (msg.type === 'relay.status') {
-        const aggregate = aggregateRelayState();
-        port.postMessage({
-          type: 'relay.status',
-          version: RELAY_WORKER_BUILD_ID,
-          state: aggregate.state,
-          code: aggregate.code,
-          reason: aggregate.reason,
-          urls: currentRelayUrls(),
-          relays: relaySnapshot(),
-        });
-        return;
-      }
-      if (msg.type === 'relay.close') {
-        desiredRelayUrls = [];
-        for (const url of currentRelayUrls()) closeRelay(url);
-        emitStatus();
-        port.postMessage({ type: 'relay.ack', ok: true });
-        return;
-      }
-    } catch (err) {
-      port.postMessage({ type: 'relay.ack', ok: false, error: String(err?.message || err) });
+function handleControlMessage(msg, endpoint) {
+  try {
+    if (msg.type === 'relay.connect') {
+      const urls = Array.isArray(msg.urls) ? msg.urls : (msg.url ? [msg.url] : []);
+      updateRelayTargets(urls);
+      endpointPost(endpoint, { type: 'relay.ack', ok: true });
+      return;
     }
-  };
+    if (msg.type === 'relay.send') {
+      send(msg.frame);
+      endpointPost(endpoint, { type: 'relay.ack', ok: true });
+      return;
+    }
+    if (msg.type === 'relay.status') {
+      const aggregate = aggregateRelayState();
+      endpointPost(endpoint, {
+        type: 'relay.status',
+        version: RELAY_WORKER_BUILD_ID,
+        state: aggregate.state,
+        code: aggregate.code,
+        reason: aggregate.reason,
+        urls: currentRelayUrls(),
+        relays: relaySnapshot(),
+      });
+      return;
+    }
+    if (msg.type === 'relay.close') {
+      desiredRelayUrls = [];
+      for (const url of currentRelayUrls()) closeRelay(url);
+      emitStatus();
+      endpointPost(endpoint, { type: 'relay.ack', ok: true });
+    }
+  } catch (err) {
+    endpointPost(endpoint, { type: 'relay.ack', ok: false, error: String(err?.message || err) });
+  }
+}
 
+function attachSharedPort(port) {
+  const endpoint = { kind: 'shared', port };
+  endpoints.add(endpoint);
+  port.onmessage = (event) => handleControlMessage(event.data || {}, endpoint);
   port.start();
-  port.postMessage({
+  endpointPost(endpoint, {
     type: 'relay.status',
     version: RELAY_WORKER_BUILD_ID,
     state: aggregateRelayState().state,
@@ -253,4 +258,30 @@ onconnect = (event) => {
     urls: currentRelayUrls(),
     relays: relaySnapshot(),
   });
+}
+
+function ensureDedicatedEndpoint() {
+  if (dedicatedEndpoint) return dedicatedEndpoint;
+  dedicatedEndpoint = { kind: 'dedicated' };
+  endpoints.add(dedicatedEndpoint);
+  endpointPost(dedicatedEndpoint, {
+    type: 'relay.status',
+    version: RELAY_WORKER_BUILD_ID,
+    state: aggregateRelayState().state,
+    code: aggregateRelayState().code,
+    reason: aggregateRelayState().reason,
+    urls: currentRelayUrls(),
+    relays: relaySnapshot(),
+  });
+  return dedicatedEndpoint;
+}
+
+self.onconnect = (event) => {
+  const port = event.ports?.[0];
+  if (port) attachSharedPort(port);
 };
+
+self.addEventListener('message', (event) => {
+  const endpoint = ensureDedicatedEndpoint();
+  handleControlMessage(event.data || {}, endpoint);
+});

--- a/relay.worker.js
+++ b/relay.worker.js
@@ -1,90 +1,215 @@
-let ws = null;
-let wsUrl = null;
-let state = 'idle';
-const ports = new Set();
-let reconnectTimer = null;
-let reconnectAttempt = 0;
-let manualClose = false;
+const RELAY_WORKER_BUILD_ID = '2026-04-03-relay-pool';
+const MAX_RECENT_EVENT_IDS = 2048;
 
-function clearReconnectTimer() {
-  if (reconnectTimer) {
-    clearTimeout(reconnectTimer);
-    reconnectTimer = null;
-  }
-}
+const ports = new Set();
+const relays = new Map();
+const recentEventIds = new Map();
+let desiredRelayUrls = [];
 
 function broadcast(msg) {
-  for (const p of ports) {
-    try { p.postMessage(msg); } catch {}
+  for (const port of ports) {
+    try { port.postMessage(msg); } catch {}
   }
 }
 
-function setState(next, extra = {}) {
-  state = next;
-  broadcast({ type: 'relay.status', state, url: wsUrl || '', ...extra });
+function currentRelayUrls() {
+  return Array.from(relays.keys());
 }
 
-function scheduleReconnect() {
-  clearReconnectTimer();
-  if (manualClose || !wsUrl) return;
-  reconnectAttempt += 1;
-  const delayMs = Math.min(15_000, 1_000 * Math.max(1, reconnectAttempt));
-  setState('connecting', { reason: `reconnect in ${delayMs}ms`, attempt: reconnectAttempt });
-  reconnectTimer = setTimeout(() => {
-    reconnectTimer = null;
-    connect(wsUrl, { isRetry: true });
+function relaySnapshot() {
+  const out = {};
+  for (const [url, relay] of relays.entries()) {
+    out[url] = {
+      state: relay.state,
+      code: relay.code ?? null,
+      reason: relay.reason ?? '',
+      attempt: relay.reconnectAttempt ?? 0,
+    };
+  }
+  return out;
+}
+
+function aggregateRelayState() {
+  if (relays.size === 0) return { state: 'offline', code: null, reason: 'no relays configured' };
+  const snapshot = Array.from(relays.values());
+  if (snapshot.some((relay) => relay.state === 'open')) return { state: 'open', code: null, reason: '' };
+  if (snapshot.some((relay) => relay.state === 'connecting')) return { state: 'connecting', code: null, reason: 'waiting for relay open' };
+  const firstFailure = snapshot.find((relay) => relay.code != null || relay.reason);
+  return {
+    state: 'error',
+    code: firstFailure?.code ?? null,
+    reason: firstFailure?.reason || 'all relays unavailable',
+  };
+}
+
+function emitStatus() {
+  const aggregate = aggregateRelayState();
+  broadcast({
+    type: 'relay.status',
+    version: RELAY_WORKER_BUILD_ID,
+    state: aggregate.state,
+    code: aggregate.code,
+    reason: aggregate.reason,
+    urls: currentRelayUrls(),
+    relays: relaySnapshot(),
+  });
+}
+
+function clearReconnect(relay) {
+  if (relay.reconnectTimer) {
+    clearTimeout(relay.reconnectTimer);
+    relay.reconnectTimer = null;
+  }
+}
+
+function rememberEventId(id) {
+  const key = String(id || '').trim();
+  if (!key) return true;
+  if (recentEventIds.has(key)) return false;
+  recentEventIds.set(key, Date.now());
+  while (recentEventIds.size > MAX_RECENT_EVENT_IDS) {
+    const oldestKey = recentEventIds.keys().next().value;
+    if (oldestKey == null) break;
+    recentEventIds.delete(oldestKey);
+  }
+  return true;
+}
+
+function extractEventId(frame) {
+  try {
+    const parsed = JSON.parse(String(frame || ''));
+    if (!Array.isArray(parsed) || parsed[0] !== 'EVENT') return '';
+    const event = parsed.length >= 3 ? parsed[2] : parsed[1];
+    const id = event && typeof event === 'object' ? String(event.id || '').trim() : '';
+    return id;
+  } catch {
+    return '';
+  }
+}
+
+function scheduleReconnect(relay) {
+  clearReconnect(relay);
+  if (!desiredRelayUrls.includes(relay.url)) return;
+  relay.reconnectAttempt += 1;
+  const delayMs = Math.min(15_000, 1_000 * Math.max(1, relay.reconnectAttempt));
+  relay.state = 'connecting';
+  relay.reason = `reconnect in ${delayMs}ms`;
+  emitStatus();
+  relay.reconnectTimer = setTimeout(() => {
+    relay.reconnectTimer = null;
+    connectRelay(relay, { isRetry: true });
   }, delayMs);
 }
 
-function connect(url, { isRetry = false } = {}) {
-  const target = String(url || '').trim();
-  if (!target) throw new Error('missing url');
-  manualClose = false;
-  clearReconnectTimer();
+function connectRelay(relay, { isRetry = false } = {}) {
+  clearReconnect(relay);
+  try { if (relay.ws) relay.ws.close(); } catch {}
+  relay.ws = null;
+  relay.state = 'connecting';
+  relay.code = null;
+  relay.reason = isRetry ? `retry ${relay.reconnectAttempt}` : '';
+  emitStatus();
 
-  if (ws && wsUrl === target && ws.readyState === WebSocket.OPEN) {
-    setState('open');
-    return;
-  }
-
-  try { if (ws) ws.close(); } catch {}
-  ws = null;
-
-  wsUrl = target;
-  setState('connecting', isRetry ? { reason: `retry ${reconnectAttempt}` } : {});
-
-  ws = new WebSocket(wsUrl);
+  const ws = new WebSocket(relay.url);
+  relay.ws = ws;
 
   ws.onopen = () => {
-    reconnectAttempt = 0;
-    setState('open');
-  };
-  ws.onerror = () => setState('error');
-  ws.onclose = (e) => {
-    setState('closed', { code: e?.code ?? null, reason: e?.reason ?? '' });
-    ws = null;
-    scheduleReconnect();
+    relay.reconnectAttempt = 0;
+    relay.state = 'open';
+    relay.code = null;
+    relay.reason = '';
+    emitStatus();
   };
 
-  ws.onmessage = (e) => {
-    broadcast({ type: 'relay.rx', data: e.data, url: wsUrl });
+  ws.onerror = () => {
+    relay.state = 'error';
+    relay.reason = relay.reason || 'socket error';
+    emitStatus();
   };
+
+  ws.onclose = (event) => {
+    relay.ws = null;
+    relay.state = 'closed';
+    relay.code = event?.code ?? null;
+    relay.reason = event?.reason ?? relay.reason ?? '';
+    emitStatus();
+    scheduleReconnect(relay);
+  };
+
+  ws.onmessage = (event) => {
+    const data = String(event.data || '');
+    const eventId = extractEventId(data);
+    if (!rememberEventId(eventId)) return;
+    broadcast({ type: 'relay.rx', data, url: relay.url });
+  };
+}
+
+function ensureRelay(url) {
+  const key = String(url || '').trim();
+  if (!key) return null;
+  if (relays.has(key)) return relays.get(key);
+  const relay = {
+    url: key,
+    ws: null,
+    state: 'offline',
+    code: null,
+    reason: '',
+    reconnectAttempt: 0,
+    reconnectTimer: null,
+  };
+  relays.set(key, relay);
+  return relay;
+}
+
+function closeRelay(url) {
+  const relay = relays.get(url);
+  if (!relay) return;
+  clearReconnect(relay);
+  try { if (relay.ws) relay.ws.close(); } catch {}
+  relays.delete(url);
+}
+
+function updateRelayTargets(urls) {
+  const nextUrls = Array.isArray(urls)
+    ? urls.map((url) => String(url || '').trim()).filter(Boolean)
+    : [];
+  desiredRelayUrls = nextUrls;
+
+  for (const url of currentRelayUrls()) {
+    if (!nextUrls.includes(url)) closeRelay(url);
+  }
+
+  for (const url of nextUrls) {
+    const relay = ensureRelay(url);
+    if (!relay) continue;
+    if (relay.ws && relay.ws.readyState === WebSocket.OPEN) continue;
+    if (relay.ws && relay.ws.readyState === WebSocket.CONNECTING) continue;
+    connectRelay(relay);
+  }
+
+  emitStatus();
 }
 
 function send(frame) {
-  if (!ws || ws.readyState !== WebSocket.OPEN) throw new Error('relay not open');
-  ws.send(String(frame));
+  let sent = false;
+  for (const relay of relays.values()) {
+    if (!relay.ws || relay.ws.readyState !== WebSocket.OPEN) continue;
+    relay.ws.send(String(frame));
+    sent = true;
+  }
+  if (!sent) throw new Error('relay not open');
 }
 
-onconnect = (e) => {
-  const port = e.ports[0];
+onconnect = (event) => {
+  const port = event.ports[0];
   ports.add(port);
 
-  port.onmessage = (ev) => {
-    const msg = ev.data || {};
+  port.onmessage = (messageEvent) => {
+    const msg = messageEvent.data || {};
     try {
       if (msg.type === 'relay.connect') {
-        connect(msg.url);
+        const urls = Array.isArray(msg.urls) ? msg.urls : (msg.url ? [msg.url] : []);
+        updateRelayTargets(urls);
         port.postMessage({ type: 'relay.ack', ok: true });
         return;
       }
@@ -94,15 +219,22 @@ onconnect = (e) => {
         return;
       }
       if (msg.type === 'relay.status') {
-        port.postMessage({ type: 'relay.status', state, url: wsUrl || '' });
+        const aggregate = aggregateRelayState();
+        port.postMessage({
+          type: 'relay.status',
+          version: RELAY_WORKER_BUILD_ID,
+          state: aggregate.state,
+          code: aggregate.code,
+          reason: aggregate.reason,
+          urls: currentRelayUrls(),
+          relays: relaySnapshot(),
+        });
         return;
       }
       if (msg.type === 'relay.close') {
-        manualClose = true;
-        clearReconnectTimer();
-        try { if (ws) ws.close(); } catch {}
-        ws = null;
-        setState('closed');
+        desiredRelayUrls = [];
+        for (const url of currentRelayUrls()) closeRelay(url);
+        emitStatus();
         port.postMessage({ type: 'relay.ack', ok: true });
         return;
       }
@@ -112,5 +244,13 @@ onconnect = (e) => {
   };
 
   port.start();
-  port.postMessage({ type: 'relay.status', state, url: wsUrl || '' });
+  port.postMessage({
+    type: 'relay.status',
+    version: RELAY_WORKER_BUILD_ID,
+    state: aggregateRelayState().state,
+    code: aggregateRelayState().code,
+    reason: aggregateRelayState().reason,
+    urls: currentRelayUrls(),
+    relays: relaySnapshot(),
+  });
 };

--- a/sw.js
+++ b/sw.js
@@ -1,9 +1,13 @@
 import { startDaemon } from './identity/sw/daemon.js';
 
+const SERVICE_WORKER_BUILD_ID = '2026-04-03-relay-pool';
+
 self.addEventListener('install', () => self.skipWaiting());
 self.addEventListener('activate', (e) => e.waitUntil(self.clients.claim()));
 
 try {
+  self.__CONSTITUTE_SW_BUILD_ID__ = SERVICE_WORKER_BUILD_ID;
+  console.info('[sw.js] boot', SERVICE_WORKER_BUILD_ID, self.location.href);
   startDaemon(self);
 } catch (e) {
   console.error('[SW] startDaemon failed', e);


### PR DESCRIPTION
## Summary
- turn Constitute into a management shell that launches first-party app surfaces instead of embedding them
- add managed launch and gateway signaling RPC/event handling for hosted services
- launch Security Cameras as a Pages-native surface with short-lived launch bootstrap

## Testing
- node --check app.js
- node --check identity/sw/rpc.js
- node --check identity/sw/relayIn.js

Closes #14
