### PR TITLE
refactor(shell): converge managed runtime ownership

### DIFF
--- a/app.js
+++ b/app.js
@@ -113,7 +113,12 @@ const SWARM_ICE_SERVERS = [
 ];
 
 const SHELL_BUILD_ID = '2026-04-06-runtime-stage3';
-const PLATFORM_RUNTIME_BUILD_ID = '2026-04-03-runtime-v1';
+const PLATFORM_RUNTIME_VERSION = Object.freeze({ major: 2, minor: 8 });
+const PLATFORM_RUNTIME_BUILD_ID = `runtime-${PLATFORM_RUNTIME_VERSION.major}.${PLATFORM_RUNTIME_VERSION.minor}`;
+const RUNTIME_ATTACH_TIMEOUT_MS = 15_000;
+const RUNTIME_WRITE_TIMEOUT_MS = 12_000;
+const MANAGED_LAUNCH_REQUEST_TIMEOUT_MS = 90_000;
+const GATEWAY_SIGNAL_REQUEST_TIMEOUT_MS = 135_000;
 const DEFAULT_PUBLIC_RELAYS = Object.freeze([
   'wss://nos.lol',
   'wss://relay.primal.net',
@@ -124,6 +129,7 @@ let relayState = 'offline';
 let daemonState = 'unknown';
 let swarmState = 'offline';
 let identityHandleCopied = false;
+let bootRefreshSettled = false;
 
 let lastDeviceState = null;
 let lastIdentity = null;
@@ -148,12 +154,9 @@ window.__constituteEnabledApps = [];
 const MANAGED_APP_SURFACES = Object.freeze({
   nvr: 'constitute-nvr-ui',
 });
-const MANAGED_LAUNCH_STORAGE_PREFIX = 'constitute.launch.';
 const MANAGED_LAUNCH_TTL_MS = 2 * 60 * 1000;
-const MANAGED_APP_CHANNEL_NAME = 'constitute.app.launch';
 const GATEWAY_INVENTORY_REFRESH_TTL_MS = 15_000;
 const GATEWAY_INVENTORY_STABLE_TTL_MS = 2 * 60 * 1000;
-const GATEWAY_HOSTED_SNAPSHOT_KEY = 'constitute.gatewayHostedSnapshots';
 const RELAY_BRIDGE_LEASE_KEY = 'constitute.relayBridge.owner';
 const RELAY_BRIDGE_LEASE_MS = 12_000;
 const RELAY_BRIDGE_HEARTBEAT_MS = 4_000;
@@ -185,13 +188,22 @@ const APPLIANCE_DISCOVERY_MAX_AGE_MS = 60 * 60 * 1000;
 
 let relayBridge = null;
 let relayPoolSnapshot = { version: '', urls: [], relays: {}, state: 'offline', reason: '' };
-const gatewayHostedSnapshotCache = loadGatewayHostedSnapshotCache();
 let runtimeBridge = null;
 let runtimeAttached = false;
-let runtimeStatusSnapshot = { buildId: '', updatedAt: 0, shell: null, services: {}, launchContextCount: 0 };
+let runtimeStatusSnapshot = {
+  buildId: '',
+  updatedAt: 0,
+  shell: null,
+  services: {},
+  managedAppliances: { owned: [], granted: [], discoverable: [] },
+  resourceNames: {},
+  managedServiceIssue: null,
+  launchContextCount: 0,
+};
 let lastManagedServiceIssue = null;
 let lastRuntimeShellStatusKey = '';
 let bootSplashDismissed = false;
+const resolvedResourceNames = new Map();
 const managedAppliances = createManagedApplianceModel({
   applyHostedSnapshot: (record) => applyGatewayHostedSnapshot(record),
   getSwarmSeen: (pk) => (swarm ? swarm.getSwarmSeen(pk) : 0),
@@ -214,10 +226,38 @@ const {
   summarizeAppliance,
 } = managedAppliances;
 
-function setBootSplash(title = 'Connecting', status = 'Bringing your identity and services online.') {
+function runtimeManagedApplianceBucket(scope) {
+  const key = String(scope || '').trim();
+  const bucket = runtimeStatusSnapshot?.managedAppliances?.[key];
+  return Array.isArray(bucket) ? bucket : [];
+}
+
+function runtimeManagedApplianceRecords() {
+  return [
+    ...runtimeManagedApplianceBucket('owned'),
+    ...runtimeManagedApplianceBucket('granted'),
+    ...runtimeManagedApplianceBucket('discoverable'),
+  ];
+}
+
+function identityOwnedDevicePks() {
+  return Array.from(ownedPkSet(lastIdentity?.devices || []));
+}
+
+function currentManagedApplianceRecords(identityDevices = lastIdentity?.devices || [], swarmDevices = lastSwarmDevices || []) {
+  const runtimeRecords = runtimeManagedApplianceRecords();
+  if (runtimeRecords.length > 0) return runtimeRecords;
+  return buildApplianceRecords(identityDevices, swarmDevices, grantedManagedServiceRecords());
+}
+
+function setBootSplash(title = 'Loading', status = '') {
   if (bootSplashDismissed || !bootSplashEl) return;
   if (bootSplashTitleEl) bootSplashTitleEl.textContent = title;
-  if (bootSplashStatusEl) bootSplashStatusEl.textContent = status;
+  if (bootSplashStatusEl) {
+    const text = String(status || '').trim();
+    bootSplashStatusEl.textContent = text;
+    bootSplashStatusEl.hidden = !text;
+  }
   document.body.classList.add('booting');
 }
 
@@ -231,35 +271,74 @@ function dismissBootSplash() {
 }
 
 function bootSplashCopy(reason = '') {
-  const detail = String(reason || '').trim();
   if (daemonState === 'online') {
     return {
       title: 'Loading',
-      status: detail || 'Restoring your devices, apps, and services.',
+      status: '',
     };
   }
   if (relayState === 'connecting') {
     return {
       title: 'Connecting',
-      status: 'Opening relay connections…',
+      status: '',
     };
   }
   if (relayState === 'open') {
     return {
-      title: 'Connecting',
-      status: detail || 'Loading your devices and services…',
+      title: 'Loading',
+      status: '',
     };
   }
   if (!clientReady) {
     return {
       title: 'Starting',
-      status: detail || 'Connecting to the local identity service…',
+      status: '',
     };
   }
   return {
-    title: 'Connecting',
-    status: detail || 'Bringing your identity and services online.',
+    title: 'Loading',
+    status: '',
   };
+}
+
+function conciseConnectionReason(summary) {
+  if (summary.code === 'connected') return 'Everything is available.';
+  if (summary.code === 'connected-limited') return 'Connected. Some services are still warming up.';
+  if (summary.code === 'degraded') return 'Connected with limited reachability.';
+  if (summary.code === 'connecting') return 'Starting local and network services.';
+  return 'Waiting for local services.';
+}
+
+function describeShellResourceName(pk, fallback = '') {
+  const key = String(pk || '').trim();
+  const raw = String(fallback || shortPk(key)).trim() || '—';
+  if (!key) {
+    return { text: raw, loading: false, raw: false };
+  }
+  const resolved = resolvedResourceNames.get(key);
+  if (resolved) {
+    return { text: resolved, loading: false, raw: false };
+  }
+  if (!bootRefreshSettled || !runtimeAttached) {
+    return { text: 'Loading name…', loading: true, raw: false };
+  }
+  return { text: raw, loading: false, raw: true };
+}
+
+function rememberResolvedResourceName(pk, label) {
+  const key = String(pk || '').trim();
+  const text = String(label || '').trim();
+  if (!key || !text) return;
+  resolvedResourceNames.set(key, text);
+}
+
+function absorbRuntimeSnapshot(snapshot) {
+  runtimeStatusSnapshot = (snapshot && typeof snapshot === 'object') ? snapshot : runtimeStatusSnapshot;
+  const names = runtimeStatusSnapshot?.resourceNames;
+  if (!names || typeof names !== 'object') return;
+  for (const [pk, label] of Object.entries(names)) {
+    rememberResolvedResourceName(pk, label);
+  }
 }
 
 function updateBootSplash(reason = '') {
@@ -351,7 +430,6 @@ const managedServiceActionStates = new Map();
 const managedServiceActionTimers = new Map();
 let gatewayBasicsModalState = null;
 let gatewayExtraZonesByPk = {};
-let managedAppChannel = null;
 const ZONE_KEY_RE = /^[A-Za-z0-9_-]{20}$/;
 const ZONE_COMMAND_DEBOUNCE_MS = 500;
 const MANAGED_SERVICE_RESOLVE_TIMEOUT_MS = 6_000;
@@ -747,7 +825,8 @@ function summarizeRelayNetwork() {
 
 function ownedApplianceRecords() {
   const owned = ownedPkSet(lastIdentity?.devices || []);
-  return buildApplianceRecords(lastIdentity?.devices || [], lastSwarmDevices || []).filter((rec) => {
+  const records = currentManagedApplianceRecords(lastIdentity?.devices || [], lastSwarmDevices || []);
+  return records.filter((rec) => {
     const pk = String(rec?.devicePk || rec?.pk || '').trim();
     const hostGatewayPk = String(rec?.hostGatewayPk || rec?.host_gateway_pk || '').trim();
     return owned.has(pk) || owned.has(hostGatewayPk);
@@ -837,11 +916,11 @@ function summarizeServices(gatewaySummary) {
       usable: ['online', 'live', 'connected', 'healthy'].includes(String(runtimeNvr.state || '').trim().toLowerCase()),
     };
   }
-  if (lastManagedServiceIssue?.service === 'nvr') {
+  if (runtimeStatusSnapshot?.managedServiceIssue?.service === 'nvr') {
     return {
       code: 'degraded',
       label: 'degraded',
-      reason: String(lastManagedServiceIssue.reason || 'Managed NVR launch failed.').trim(),
+      reason: String(runtimeStatusSnapshot.managedServiceIssue.reason || 'Managed NVR launch failed.').trim(),
       usable: false,
     };
   }
@@ -944,6 +1023,7 @@ function connectionTextClass(code) {
 
 function renderConnectionModel(reason = '') {
   const summary = connectionSummary();
+  const conciseReason = conciseConnectionReason(summary);
   if (connStateText) {
     connStateText.textContent = summary.label;
     connStateText.classList.remove('connStateText-connected', 'connStateText-limited', 'connStateText-error');
@@ -954,11 +1034,11 @@ function renderConnectionModel(reason = '') {
   if (networkStatusGatewayMeshEl) networkStatusGatewayMeshEl.textContent = summary.gateway.label;
   if (networkStatusServicesEl) networkStatusServicesEl.textContent = summary.services.label;
   if (networkStatusDetailEl) {
-    networkStatusDetailEl.textContent = summary.reason;
+    networkStatusDetailEl.textContent = conciseReason;
   }
 
   if (popConnection) popConnection.textContent = summary.label;
-  if (popConnectionReason) popConnectionReason.textContent = summary.reason;
+  if (popConnectionReason) popConnectionReason.textContent = conciseReason;
   if (popRelay) popRelay.textContent = summary.relay.label;
   if (popGateway) popGateway.textContent = summary.gateway.label;
   if (popServices) popServices.textContent = summary.services.label;
@@ -1196,65 +1276,6 @@ function browserPrefersDedicatedRelayWorker() {
   }
 }
 
-function managedLaunchStorageKey(launchId) {
-  return `${MANAGED_LAUNCH_STORAGE_PREFIX}${String(launchId || '').trim()}`;
-}
-
-function cleanupManagedLaunchContexts() {
-  try {
-    const now = Date.now();
-    const keys = [];
-    for (let i = 0; i < localStorage.length; i += 1) {
-      const key = localStorage.key(i);
-      if (key && key.startsWith(MANAGED_LAUNCH_STORAGE_PREFIX)) keys.push(key);
-    }
-    for (const key of keys) {
-      try {
-        const raw = localStorage.getItem(key);
-        const parsed = raw ? JSON.parse(raw) : null;
-        const expiresAt = Number(parsed?.expiresAt || parsed?.createdAt || 0);
-        if (!parsed || !expiresAt || expiresAt < now) {
-          localStorage.removeItem(key);
-        }
-      } catch {
-        localStorage.removeItem(key);
-      }
-    }
-  } catch {}
-}
-
-function readManagedLaunchContext(launchId) {
-  const id = String(launchId || '').trim();
-  if (!id) return null;
-  cleanupManagedLaunchContexts();
-  try {
-    const raw = localStorage.getItem(managedLaunchStorageKey(id));
-    if (!raw) return null;
-    const parsed = JSON.parse(raw);
-    const expiresAt = Number(parsed?.expiresAt || 0);
-    if (expiresAt && expiresAt < Date.now()) {
-      localStorage.removeItem(managedLaunchStorageKey(id));
-      return null;
-    }
-    return parsed && typeof parsed === 'object' ? parsed : null;
-  } catch {
-    return null;
-  }
-}
-
-function writeManagedLaunchContext(context) {
-  const launchId = String(context?.launchId || '').trim();
-  if (!launchId) throw new Error('launch context missing launchId');
-  cleanupManagedLaunchContexts();
-  const payload = {
-    ...context,
-    createdAt: Number(context?.createdAt || Date.now()),
-    expiresAt: Number(context?.expiresAt || (Date.now() + MANAGED_LAUNCH_TTL_MS)),
-  };
-  localStorage.setItem(managedLaunchStorageKey(launchId), JSON.stringify(payload));
-  return payload;
-}
-
 function runtimeWorkerScriptUrl() {
   const target = new URL('./runtime.worker.js', window.location.href);
   target.searchParams.set('v', PLATFORM_RUNTIME_BUILD_ID);
@@ -1371,7 +1392,7 @@ function isManagedFirstPartyApp(app) {
 
 function startPlatformRuntimeBridge() {
   if (typeof SharedWorker === 'undefined') {
-    console.warn('[runtime] SharedWorker unavailable; using legacy managed app channel only');
+    console.warn('[runtime] SharedWorker unavailable; managed app surfaces require the shared runtime');
     return null;
   }
 
@@ -1380,7 +1401,7 @@ function startPlatformRuntimeBridge() {
   try {
     worker = new SharedWorker(runtimeWorkerScriptUrl());
   } catch (err) {
-    console.warn('[runtime] SharedWorker attach failed; using legacy managed app channel only', err);
+    console.warn('[runtime] SharedWorker attach failed', err);
     return null;
   }
   const port = worker.port;
@@ -1392,14 +1413,39 @@ function startPlatformRuntimeBridge() {
     requestId: 1,
     pending: new Map(),
     snapshot: null,
+    ready: false,
+    readyPromise: null,
+    resolveReady: null,
+    rejectReady: null,
     close() {
       try {
-        port.postMessage({ type: 'runtime.detach', clientId });
-      } catch {}
-      try {
-        port.close();
+      port.postMessage({ type: 'runtime.detach', clientId });
+    } catch {}
+    try {
+      port.close();
       } catch {}
     },
+  };
+  bridge.readyPromise = new Promise((resolve, reject) => {
+    bridge.resolveReady = resolve;
+    bridge.rejectReady = reject;
+  });
+  try {
+    worker.onerror = (event) => {
+      bridge.rejectReady?.(new Error(String(event?.message || 'shared worker failure')));
+      bridge.rejectReady = null;
+      bridge.resolveReady = null;
+      console.error('[runtime] SharedWorker error', event?.message || event);
+    };
+  } catch {}
+  bridge.whenReady = async (timeoutMs = RUNTIME_ATTACH_TIMEOUT_MS) => {
+    if (bridge.ready) return bridge.snapshot;
+    return await Promise.race([
+      bridge.readyPromise,
+      new Promise((_, reject) => {
+        window.setTimeout(() => reject(new Error('runtime.attach timed out')), timeoutMs);
+      }),
+    ]);
   };
 
   function runtimeCall(type, payload = {}, timeoutMs = 20_000) {
@@ -1416,18 +1462,25 @@ function startPlatformRuntimeBridge() {
 
   bridge.call = runtimeCall;
   bridge.putLaunchContext = async (context) => {
-    await runtimeCall('launchContext.put', { context }, 5_000).catch((err) => {
-      console.warn('[runtime] launchContext.put failed', err);
-    });
+    await bridge.whenReady();
+    return await runtimeCall('launchContext.put', { context }, RUNTIME_WRITE_TIMEOUT_MS);
   };
   bridge.pushStatus = async (status) => {
-    await runtimeCall('status.update', { role: 'shell', status }, 5_000).catch((err) => {
-      console.warn('[runtime] status.update failed', err);
+    await bridge.whenReady().catch((err) => {
+      console.warn('[runtime] runtime attach failed', err);
+    });
+    if (!bridge.ready) return;
+    await runtimeCall('runtime.status.put', { role: 'shell', status }, RUNTIME_WRITE_TIMEOUT_MS).catch((err) => {
+      console.warn('[runtime] runtime.status.put failed', err);
     });
   };
-  bridge.putProjection = async (category, key, value) => {
-    await runtimeCall('projection.put', { category, key, value }, 5_000).catch((err) => {
-      console.warn('[runtime] projection.put failed', err);
+  bridge.putManagedApplianceSourceSnapshot = async (sourceSnapshot) => {
+    await bridge.whenReady().catch((err) => {
+      console.warn('[runtime] runtime attach failed', err);
+    });
+    if (!bridge.ready) return;
+    await runtimeCall('managedAppliances.sourceSnapshot.put', { sourceSnapshot }, RUNTIME_WRITE_TIMEOUT_MS).catch((err) => {
+      console.warn('[runtime] managedAppliances.sourceSnapshot.put failed', err);
     });
   };
 
@@ -1435,20 +1488,39 @@ function startPlatformRuntimeBridge() {
     const msg = event?.data || {};
     if (msg.type === 'runtime.attached') {
       runtimeAttached = true;
+      bridge.ready = true;
       bridge.snapshot = msg.snapshot || null;
-      runtimeStatusSnapshot = msg.snapshot || runtimeStatusSnapshot;
+      absorbRuntimeSnapshot(msg.snapshot || null);
+      lastManagedServiceIssue = runtimeStatusSnapshot?.managedServiceIssue || null;
+      bridge.resolveReady?.(bridge.snapshot);
+      bridge.resolveReady = null;
+      bridge.rejectReady = null;
+      renderConnectionModel();
+      renderHomeApps();
+      if (lastIdentity) renderApplianceList(lastIdentity?.devices || [], lastSwarmDevices || []);
       return;
     }
-    if (msg.type === 'status.snapshot') {
+    if (msg.type === 'runtime.snapshot') {
+      if (!bridge.ready) {
+        bridge.ready = true;
+        bridge.resolveReady?.(msg.snapshot || null);
+        bridge.resolveReady = null;
+        bridge.rejectReady = null;
+      }
       bridge.snapshot = msg.snapshot || null;
-      runtimeStatusSnapshot = msg.snapshot || runtimeStatusSnapshot;
+      absorbRuntimeSnapshot(msg.snapshot || null);
+      lastManagedServiceIssue = runtimeStatusSnapshot?.managedServiceIssue || null;
       renderConnectionModel();
+      renderHomeApps();
+      if (lastIdentity) renderApplianceList(lastIdentity?.devices || [], lastSwarmDevices || []);
       return;
     }
     if (msg.type === 'runtime.broker.request') {
       handleRuntimeBrokerRequest(msg).catch((err) => {
         const kind = String(msg?.kind || '').trim();
-        const responseType = kind === 'gateway.launch.request' ? 'gateway.launch.response' : 'gateway.signal.response';
+        const responseType = kind === 'gateway.launch.request'
+          ? 'gateway.launch.response'
+          : (kind === 'gateway.grant.request' ? 'gateway.grant.response' : 'gateway.signal.response');
         port.postMessage({
           type: responseType,
           clientId,
@@ -1482,7 +1554,6 @@ function startPlatformRuntimeBridge() {
     surface: 'shell',
     broker: true,
   });
-  port.postMessage({ type: 'status.snapshot', clientId });
   return bridge;
 }
 
@@ -1492,31 +1563,7 @@ async function handleRuntimeBrokerRequest(message) {
   if (!runtimeBridge || !requestId || !kind) return;
   const payload = message?.payload && typeof message.payload === 'object' ? message.payload : {};
   if (kind === 'gateway.signal.request') {
-    const signalRequestId = String(payload?.requestId || '').trim();
-    let result;
-    try {
-      result = await requestGatewaySignal(payload);
-    } catch (err) {
-      const channel = ensureManagedAppChannel();
-      if (channel && signalRequestId) {
-        channel.postMessage({
-          type: 'gateway.signal.response',
-          requestId: signalRequestId,
-          ok: false,
-          error: String(err?.message || err),
-        });
-      }
-      throw err;
-    }
-    const channel = ensureManagedAppChannel();
-    if (channel && signalRequestId) {
-      channel.postMessage({
-        type: 'gateway.signal.response',
-        requestId: signalRequestId,
-        ok: true,
-        result,
-      });
-    }
+    const result = await requestGatewaySignal(payload);
     runtimeBridge.port.postMessage({
       type: 'gateway.signal.response',
       clientId: runtimeBridge.clientId,
@@ -1537,174 +1584,29 @@ async function handleRuntimeBrokerRequest(message) {
     });
     return;
   }
+  if (kind === 'gateway.grant.request') {
+    const record = {
+      devicePk: String(payload?.servicePk || '').trim(),
+      hostGatewayPk: String(payload?.gatewayPk || '').trim(),
+      service: String(payload?.service || 'nvr').trim() || 'nvr',
+    };
+    const result = await requestGatewayGrantAction(record, {
+      action: String(payload?.action || '').trim(),
+      granteeIdentityId: String(payload?.granteeIdentityId || '').trim(),
+      grantId: String(payload?.grantId || '').trim(),
+      viewSources: Array.isArray(payload?.viewSources) ? payload.viewSources : [],
+      controlSources: Array.isArray(payload?.controlSources) ? payload.controlSources : [],
+    });
+    runtimeBridge.port.postMessage({
+      type: 'gateway.grant.response',
+      clientId: runtimeBridge.clientId,
+      requestId,
+      ok: true,
+      result,
+    });
+    return;
+  }
   throw new Error(`unsupported broker request: ${kind}`);
-}
-
-function ensureManagedAppChannel() {
-  if (managedAppChannel || typeof BroadcastChannel === 'undefined') return managedAppChannel;
-  managedAppChannel = new BroadcastChannel(MANAGED_APP_CHANNEL_NAME);
-  managedAppChannel.onmessage = (event) => {
-    handleManagedAppChannelMessage(event?.data || {}).catch((err) => {
-      console.error('managed app channel message failed', err);
-    });
-  };
-  return managedAppChannel;
-}
-
-async function handleManagedAppChannelMessage(message) {
-  const type = String(message?.type || '').trim();
-  const channel = ensureManagedAppChannel();
-  if (!type || !channel) return;
-
-  if (type === 'launch-context.request') {
-    const launchId = String(message?.launchId || '').trim();
-    if (!launchId) return;
-    const context = readManagedLaunchContext(launchId);
-    channel.postMessage({
-      type: 'launch-context.response',
-      launchId,
-      ok: !!context,
-      context,
-      error: context ? '' : 'launch context unavailable',
-    });
-    return;
-  }
-
-  if (type === 'gateway.launch.request') {
-    const requestId = String(message?.requestId || '').trim() || randomOpaqueId('gw-launch-ui');
-    const launchId = String(message?.launchId || '').trim();
-    const context = readManagedLaunchContext(launchId);
-    const record = (message?.record && typeof message.record === 'object')
-      ? message.record
-      : (context ? {
-          devicePk: context.servicePk,
-          pk: context.servicePk,
-          hostGatewayPk: context.gatewayPk,
-          service: context.service || 'nvr',
-        } : null);
-    const options = (message?.options && typeof message.options === 'object') ? message.options : {};
-    if (!record) {
-      channel.postMessage({
-        type: 'gateway.launch.response',
-        launchId,
-        requestId,
-        ok: false,
-        error: 'launch refresh context unavailable',
-      });
-      return;
-    }
-
-    try {
-      const result = await requestGatewayManagedLaunch(record, options);
-      channel.postMessage({
-        type: 'gateway.launch.response',
-        launchId,
-        requestId,
-        ok: true,
-        result,
-      });
-    } catch (err) {
-      channel.postMessage({
-        type: 'gateway.launch.response',
-        launchId,
-        requestId,
-        ok: false,
-        error: String(err?.message || err),
-      });
-    }
-    return;
-  }
-
-  if (type === 'gateway.signal.request') {
-    const requestId = String(message?.requestId || '').trim() || randomOpaqueId('gw-signal-ui');
-    const launchId = String(message?.launchId || '').trim();
-    const context = readManagedLaunchContext(launchId);
-    if (!context) {
-      channel.postMessage({
-        type: 'gateway.signal.response',
-        launchId,
-        requestId,
-        ok: false,
-        error: 'launch context unavailable',
-      });
-      return;
-    }
-
-    try {
-      const result = await requestGatewaySignal({
-        requestId,
-        gatewayPk: context.gatewayPk,
-        servicePk: context.servicePk,
-        service: context.service || 'nvr',
-        launchToken: context.launchToken,
-        signalType: String(message?.signalType || '').trim(),
-        payload: message?.payload ?? {},
-      });
-      channel.postMessage({
-        type: 'gateway.signal.response',
-        launchId,
-        requestId,
-        ok: true,
-        result,
-      });
-    } catch (err) {
-      channel.postMessage({
-        type: 'gateway.signal.response',
-        launchId,
-        requestId,
-        ok: false,
-        error: String(err?.message || err),
-      });
-    }
-    return;
-  }
-
-  if (type === 'gateway.grant.request') {
-    const requestId = String(message?.requestId || '').trim() || randomOpaqueId('gw-grant-ui');
-    const launchId = String(message?.launchId || '').trim();
-    const context = readManagedLaunchContext(launchId);
-    if (!context) {
-      channel.postMessage({
-        type: 'gateway.grant.response',
-        launchId,
-        requestId,
-        ok: false,
-        error: 'launch context unavailable',
-      });
-      return;
-    }
-
-    try {
-      const record = {
-        devicePk: context.servicePk,
-        hostGatewayPk: context.gatewayPk,
-        service: context.service || 'nvr',
-      };
-      const result = await requestGatewayGrantAction(record, {
-        action: String(message?.action || '').trim(),
-        granteeIdentityId: String(message?.granteeIdentityId || '').trim(),
-        grantId: String(message?.grantId || '').trim(),
-        viewSources: Array.isArray(message?.viewSources) ? message.viewSources : [],
-        controlSources: Array.isArray(message?.controlSources) ? message.controlSources : [],
-      });
-      channel.postMessage({
-        type: 'gateway.grant.response',
-        launchId,
-        requestId,
-        ok: true,
-        result,
-      });
-    } catch (err) {
-      channel.postMessage({
-        type: 'gateway.grant.response',
-        launchId,
-        requestId,
-        ok: false,
-        error: String(err?.message || err),
-      });
-    }
-    return;
-  }
 }
 
 function summarizeInstallDetail(detail) {
@@ -1772,6 +1674,7 @@ function handleGatewayManagedLaunchStatusEvent(evt) {
 
   if (status === 'complete') {
     lastManagedServiceIssue = null;
+    publishRuntimeManagedApplianceState();
     settlePending(pendingManagedLaunches, requestId, null, {
       requestId,
       gatewayPk: String(evt?.gatewayPk || '').trim(),
@@ -1795,6 +1698,7 @@ function handleGatewayManagedLaunchStatusEvent(evt) {
       reason: detail || 'managed launch failed',
       updatedAt: Date.now(),
     };
+    publishRuntimeManagedApplianceState();
     renderConnectionModel(detail);
     requestGatewayInventoryRefresh(String(evt?.gatewayPk || '').trim(), { force: true }).catch(() => false);
     refreshManagedApplianceProjection({ refreshGrantViews: false }).catch(() => {});
@@ -1854,6 +1758,7 @@ function handleGatewaySignalStatusRelayEvent(evt) {
       reason: detail || 'gateway signal failed',
       updatedAt: Date.now(),
     };
+    publishRuntimeManagedApplianceState();
     renderConnectionModel(detail);
     settlePending(pendingGatewaySignals, requestId, new Error(detail || 'gateway signal failed'));
     return;
@@ -2312,34 +2217,52 @@ async function requestGatewayManagedLaunch(record, opts = {}) {
   if (!servicePk) throw new Error('service public key is missing');
   if (!String(lastIdentity?.id || '').trim()) throw new Error('link an identity before opening managed services');
   if (!String(lastDeviceState?.pk || '').trim()) throw new Error('device key is not ready yet');
-
-  const requestId = randomOpaqueId('gw-launch');
-  const pending = createPendingRequest(pendingManagedLaunches, requestId, 'managed launch', 20_000);
-  try {
-    await client.call('gateway.managedLaunch.request', {
-      requestId,
-      gatewayPk,
-      servicePk,
-      service,
-      capability,
-      appRepo: managedAppSurfaceRepoForService(service),
-      display: {
-        shell: 'constitute',
-        surface: managedAppSurfaceRepoForService(service),
-      },
-    }, { timeoutMs: 20_000 });
-  } catch (err) {
-    settlePending(pendingManagedLaunches, requestId, err);
-    throw err;
+  const requestLaunchOnce = async () => {
+    const requestId = randomOpaqueId('gw-launch');
+    const pending = createPendingRequest(pendingManagedLaunches, requestId, 'managed launch', MANAGED_LAUNCH_REQUEST_TIMEOUT_MS);
+    try {
+      await client.call('gateway.managedLaunch.request', {
+        requestId,
+        gatewayPk,
+        servicePk,
+        service,
+        capability,
+        appRepo: managedAppSurfaceRepoForService(service),
+        display: {
+          shell: 'constitute',
+          surface: managedAppSurfaceRepoForService(service),
+        },
+      }, { timeoutMs: MANAGED_LAUNCH_REQUEST_TIMEOUT_MS });
+    } catch (err) {
+      settlePending(pendingManagedLaunches, requestId, err);
+      throw err;
+    }
+    return await pending;
+  };
+  for (let attempt = 1; attempt <= 3; attempt += 1) {
+    try {
+      return await requestLaunchOnce();
+    } catch (err) {
+      const message = String(err?.message || err || '').trim().toLowerCase();
+      const canRetry = message.includes('managed launch timed out') && attempt < 3;
+      if (!canRetry) throw err;
+      console.warn('[managed] managed launch timed out; retrying', {
+        gatewayPk,
+        servicePk,
+        service,
+        attempt,
+      });
+    }
   }
-  return await pending;
 }
 
 async function requestGatewaySignal(req) {
   const requestId = String(req?.requestId || '').trim() || randomOpaqueId('gw-signal');
   const signalType = String(req?.signalType || '').trim().toLowerCase();
   if (!signalType) throw new Error('missing signal type');
-  const pending = createPendingRequest(pendingGatewaySignals, requestId, `gateway ${signalType}`, 30_000);
+  const pendingTimeoutMs = signalType === 'offer' ? 30_000 : GATEWAY_SIGNAL_REQUEST_TIMEOUT_MS;
+  const callTimeoutMs = signalType === 'offer' ? 30_000 : GATEWAY_SIGNAL_REQUEST_TIMEOUT_MS;
+  const pending = createPendingRequest(pendingGatewaySignals, requestId, `gateway ${signalType}`, pendingTimeoutMs);
   try {
     await client.call('gateway.signal.request', {
       requestId,
@@ -2349,7 +2272,7 @@ async function requestGatewaySignal(req) {
       signalType,
       payload: req?.payload ?? {},
       launchToken: String(req?.launchToken || '').trim(),
-    }, { timeoutMs: 20_000 });
+    }, { timeoutMs: callTimeoutMs });
   } catch (err) {
     settlePending(pendingGatewaySignals, requestId, err);
     throw err;
@@ -2488,7 +2411,7 @@ async function requestGatewayGrantAction(record, opts = {}) {
 
 async function refreshGatewayGrantViews(identityDevices, swarmDevices) {
   const owned = ownedPkSet(identityDevices);
-  const applianceRecords = buildApplianceRecords(identityDevices, swarmDevices);
+  const applianceRecords = currentManagedApplianceRecords(identityDevices, swarmDevices);
   const nextShared = new Map();
   const nextGrantInventory = new Map();
 
@@ -2561,7 +2484,8 @@ function launchAppWindow(app) {
   }
 }
 
-function managedPopupSplashHtml(title = 'Connecting', status = 'Preparing your Security Cameras view.') {
+function managedPopupSplashHtml(title = 'Connecting', status = '') {
+  const nextStatus = String(status || '').trim();
   return `<!doctype html>
 <html lang="en">
 <head>
@@ -2630,7 +2554,7 @@ function managedPopupSplashHtml(title = 'Connecting', status = 'Preparing your S
   <div class="bootSplashCard" aria-live="polite" role="status">
     <div class="bootSpinner" aria-hidden="true"></div>
     <p class="bootSplashTitle">${escapeHtml(title)}</p>
-    <p class="bootSplashStatus">${escapeHtml(status)}</p>
+    <p class="bootSplashStatus"${nextStatus ? '' : ' hidden'}>${escapeHtml(nextStatus)}</p>
   </div>
 </body>
 </html>`;
@@ -2640,6 +2564,7 @@ async function launchNvrControlPanel(record, opts = {}) {
   let popup = null;
   try {
     lastManagedServiceIssue = null;
+    publishRuntimeManagedApplianceState();
     setManagedServiceActionState(record, {
       state: 'resolving',
       message: 'Resolving current Security Cameras availability…',
@@ -2647,7 +2572,7 @@ async function launchNvrControlPanel(record, opts = {}) {
     popup = window.open('', '_blank');
     if (popup && !popup.closed) {
       popup.document.open();
-      popup.document.write(managedPopupSplashHtml('Connecting', 'Resolving current Security Cameras availability.'));
+      popup.document.write(managedPopupSplashHtml('Connecting'));
       popup.document.close();
     }
 
@@ -2658,7 +2583,7 @@ async function launchNvrControlPanel(record, opts = {}) {
     });
     if (popup && !popup.closed) {
       popup.document.open();
-      popup.document.write(managedPopupSplashHtml('Connecting', 'Preparing your Security Cameras view.'));
+      popup.document.write(managedPopupSplashHtml('Connecting'));
       popup.document.close();
     }
 
@@ -2668,7 +2593,10 @@ async function launchNvrControlPanel(record, opts = {}) {
     });
 
     const launchId = randomOpaqueId('launch');
-    const context = writeManagedLaunchContext({
+    if (!runtimeBridge?.putLaunchContext) {
+      throw new Error('shared browser runtime is unavailable; reload Constitute and try again');
+    }
+    const context = {
       launchId,
       app: 'nvr',
       repo: managedAppSurfaceRepoForService('nvr'),
@@ -2681,8 +2609,8 @@ async function launchNvrControlPanel(record, opts = {}) {
       display: launch?.display ?? {},
       createdAt: Date.now(),
       expiresAt: Number(launch?.expiresAt || (Date.now() + MANAGED_LAUNCH_TTL_MS)),
-    });
-    await runtimeBridge?.putLaunchContext?.(context);
+    };
+    await runtimeBridge.putLaunchContext(context);
 
     const url = await buildManagedAppSurfaceUrl(
       managedAppSurfaceRepoForService('nvr'),
@@ -2704,6 +2632,7 @@ async function launchNvrControlPanel(record, opts = {}) {
       reason: String(err?.message || err),
       updatedAt: Date.now(),
     };
+    publishRuntimeManagedApplianceState();
     setGatewayInstallStatus(`NVR control panel failed: ${String(err?.message || err)}`, true);
     runtimeBridge?.pushStatus?.(buildRuntimeShellStatus()).catch(() => {});
     setManagedServiceActionState(record, {
@@ -2844,7 +2773,7 @@ async function refreshManagedApplianceProjection(opts = {}) {
     await refreshGatewayGrantViews(lastIdentity?.devices || [], lastSwarmDevices).catch(() => {});
   }
   renderApplianceList(lastIdentity?.devices || [], lastSwarmDevices);
-  pushRuntimeApplianceProjections(lastIdentity?.devices || [], lastSwarmDevices);
+  pushRuntimeManagedApplianceSourceSnapshot(lastIdentity?.devices || [], lastSwarmDevices);
   renderConnectionModel('managed inventory refresh');
   return lastSwarmDevices;
 }
@@ -2889,7 +2818,7 @@ async function resolveManagedServiceForLaunch(record, opts = {}) {
   }
   let candidate = resolvedManagedServiceRecord(
     record,
-    buildApplianceRecords(lastIdentity?.devices || [], lastSwarmDevices || [], grantedManagedServiceRecords()),
+    currentManagedApplianceRecords(lastIdentity?.devices || [], lastSwarmDevices || []),
   );
   if (candidate && isFreshManagedServiceRecord(candidate) && isGatewayAuthoritativeManagedServiceRecord(candidate)) {
     return candidate;
@@ -2901,7 +2830,7 @@ async function resolveManagedServiceForLaunch(record, opts = {}) {
     await refreshManagedApplianceProjection({ refreshGrantViews: false }).catch(() => {});
     candidate = resolvedManagedServiceRecord(
       record,
-      buildApplianceRecords(lastIdentity?.devices || [], lastSwarmDevices || [], grantedManagedServiceRecords()),
+      currentManagedApplianceRecords(lastIdentity?.devices || [], lastSwarmDevices || []),
     );
     if (candidate && isFreshManagedServiceRecord(candidate) && isGatewayAuthoritativeManagedServiceRecord(candidate)) {
       return candidate;
@@ -2925,10 +2854,13 @@ async function resolveManagedServiceForLaunch(record, opts = {}) {
 }
 
 function renderApplianceList(identityDevices, swarmDevices) {
+  const applianceRecords = currentManagedApplianceRecords(identityDevices, swarmDevices);
   renderManagedApplianceList({
     applianceList,
     identityDevices,
     swarmDevices,
+    applianceRecords,
+    ownedDevicePks: identityOwnedDevicePks(),
     gatewayInventoryStableAt,
     showActivity,
     setSettingsTab,
@@ -2942,6 +2874,7 @@ function renderApplianceList(identityDevices, swarmDevices) {
     launchNvrControlPanel,
     openGatewayBasicsModal,
     escapeHtml,
+    describeResourceName: describeShellResourceName,
     getManagedServiceActionState: managedServiceActionStateForRecord,
     grantedRecords: grantedManagedServiceRecords(),
     getGrantInventoryForService,
@@ -2950,20 +2883,18 @@ function renderApplianceList(identityDevices, swarmDevices) {
   });
 }
 
-function pushRuntimeApplianceProjections(identityDevices, swarmDevices) {
-  if (!runtimeBridge?.putProjection) return;
-  const grantedRecords = grantedManagedServiceRecords();
-  const combinedRecords = buildApplianceRecords(identityDevices, swarmDevices, grantedRecords);
-  const owned = ownedPkSet(identityDevices);
-  const partitions = partitionApplianceRecords(
-    combinedRecords,
-    owned,
-    (record) => record?.sharedProjection === true || record?.grantedRecord === true,
-  );
-  runtimeBridge.putProjection('owned', 'appliances', partitions.ownedRecords);
-  runtimeBridge.putProjection('granted', 'appliances', partitions.grantedRecords);
-  runtimeBridge.putProjection('discoverable', 'appliances', partitions.discoverableRecords);
-  runtimeBridge.putProjection('session', 'managed-service-issue', lastManagedServiceIssue || null);
+function pushRuntimeManagedApplianceSourceSnapshot(identityDevices, swarmDevices) {
+  if (!runtimeBridge?.putManagedApplianceSourceSnapshot) return;
+  runtimeBridge.putManagedApplianceSourceSnapshot({
+    identityDevices: Array.isArray(identityDevices) ? identityDevices : [],
+    swarmDevices: Array.isArray(swarmDevices) ? swarmDevices : [],
+    grantedRecords: grantedManagedServiceRecords(),
+    managedServiceIssue: lastManagedServiceIssue || null,
+  });
+}
+
+function publishRuntimeManagedApplianceState() {
+  pushRuntimeManagedApplianceSourceSnapshot(lastIdentity?.devices || [], lastSwarmDevices || []);
 }
 
 function loadAppPrefs() {
@@ -3023,69 +2954,8 @@ function normalizeRole(value) {
   return String(value || '').trim().toLowerCase();
 }
 
-function loadGatewayHostedSnapshotCache() {
-  try {
-    const raw = localStorage.getItem(GATEWAY_HOSTED_SNAPSHOT_KEY);
-    const parsed = raw ? JSON.parse(raw) : {};
-    return (parsed && typeof parsed === 'object') ? parsed : {};
-  } catch {
-    return {};
-  }
-}
-
-function saveGatewayHostedSnapshotCache() {
-  try {
-    localStorage.setItem(GATEWAY_HOSTED_SNAPSHOT_KEY, JSON.stringify(gatewayHostedSnapshotCache));
-  } catch {}
-}
-
-function normalizeHostedServices(value) {
-  if (!Array.isArray(value)) return [];
-  return value
-    .map((entry) => (entry && typeof entry === 'object') ? entry : null)
-    .filter(Boolean);
-}
-
-function gatewayHostedSnapshot(record) {
-  const pk = String(record?.devicePk || record?.pk || '').trim();
-  const updatedAt = Number(record?.updatedAt || record?.updated_at || record?.ts || 0);
-  const hostedServices = normalizeHostedServices(record?.hostedServices || record?.hosted_services);
-  return { pk, updatedAt, hostedServices };
-}
-
 function applyGatewayHostedSnapshot(record) {
-  if (!isGatewayRecord(record)) return record;
-
-  const current = gatewayHostedSnapshot(record);
-  if (!current.pk) return record;
-
-  const cached = gatewayHostedSnapshotCache[current.pk] || null;
-  let effectiveHostedServices = current.hostedServices;
-
-  if (effectiveHostedServices.length > 0) {
-    gatewayHostedSnapshotCache[current.pk] = {
-      updatedAt: current.updatedAt,
-      hostedServices: effectiveHostedServices,
-    };
-    saveGatewayHostedSnapshotCache();
-  } else if (cached && Array.isArray(cached.hostedServices) && cached.hostedServices.length > 0) {
-    const cachedUpdatedAt = Number(cached.updatedAt || 0);
-    if (cachedUpdatedAt >= current.updatedAt) {
-      effectiveHostedServices = cached.hostedServices;
-    } else if (current.updatedAt >= cachedUpdatedAt) {
-      gatewayHostedSnapshotCache[current.pk] = {
-        updatedAt: current.updatedAt,
-        hostedServices: [],
-      };
-      saveGatewayHostedSnapshotCache();
-    }
-  }
-
-  if (effectiveHostedServices === current.hostedServices) return record;
-  return {
-    ...record,
-    hostedServices: effectiveHostedServices,
-  };
+  return record;
 }
 
 function pageAllowsInsecureRelayUrls() {
@@ -3570,7 +3440,7 @@ function renderHomeApps() {
   if (!homeAppsList) return;
 
   const apps = enabledAppManifests().filter((app) => !isManagedFirstPartyApp(app));
-  const managedServices = buildApplianceRecords(lastIdentity?.devices || [], lastSwarmDevices, grantedManagedServiceRecords())
+  const managedServices = currentManagedApplianceRecords(lastIdentity?.devices || [], lastSwarmDevices)
     .filter((rec) => isNvrRecord(rec))
     .filter((rec) => {
       const pk = String(rec?.devicePk || rec?.pk || '').trim();
@@ -3620,6 +3490,7 @@ function renderHomeApps() {
 
   for (const rec of managedServices) {
     const info = summarizeAppliance(rec, true);
+    const gatewayDescriptor = describeShellResourceName(info.hostGatewayPk, shortPk(info.hostGatewayPk));
     const row = document.createElement('div');
     row.className = 'item appItem';
 
@@ -3636,7 +3507,11 @@ function renderHomeApps() {
       rec?.sharedProjection === true || rec?.grantedRecord === true ? 'Shared service' : 'Managed service',
       `service ${info.service || 'nvr'}`,
     ];
-    if (info.hostGatewayPk) parts.push(`gateway ${info.hostGatewayPk.slice(0, 12)}...`);
+    if (info.hostGatewayPk) {
+      if (gatewayDescriptor.loading) parts.push('gateway name loading…');
+      else if (gatewayDescriptor.raw) parts.push(`gateway id ${gatewayDescriptor.text}`);
+      else parts.push(`gateway ${gatewayDescriptor.text}`);
+    }
     meta.textContent = parts.join(' - ');
 
     text.appendChild(title);
@@ -4225,9 +4100,9 @@ async function refreshAll() {
   setDaemonState('online', 'rpc ok');
 
   deviceDid.textContent = st.did || '';
-  deviceDidSummary.textContent = st.did || '(none)';
-  deviceSecuritySummary.textContent = st.didMethod === 'webauthn' ? 'platform-backed' : 'software-only';
-  identityLinkedSummary.textContent = ident?.linked ? 'yes' : 'no';
+  deviceDidSummary.textContent = String(myLabel?.label || 'This device').trim() || 'This device';
+  deviceSecuritySummary.textContent = st.didMethod === 'webauthn' ? 'Protected' : 'Basic';
+  identityLinkedSummary.textContent = ident?.linked ? currentIdentityHandle() : 'Not signed in';
   updateIdentityChrome(ident);
 
   deviceLabel.value = myLabel?.label || '';
@@ -4239,12 +4114,12 @@ async function refreshAll() {
   renderPeers(lastDirectory);
   updateZoneCommandUi();
   renderApplianceList(ident?.devices || [], lastSwarmDevices);
-  pushRuntimeApplianceProjections(ident?.devices || [], lastSwarmDevices);
+  pushRuntimeManagedApplianceSourceSnapshot(ident?.devices || [], lastSwarmDevices);
   renderHomeApps();
   renderPairRequests(reqs || [], ident?.devices || []);
   renderNotifications(notifs || []);
   ensureOnboardingState(ident);
-  const applianceRecords = buildApplianceRecords(ident?.devices || [], lastSwarmDevices);
+  const applianceRecords = currentManagedApplianceRecords(ident?.devices || [], lastSwarmDevices);
   const ownedGatewayPksNeedingRefresh = applianceRecords
     .filter((rec) => isGatewayRecord(rec))
     .map((rec) => summarizeAppliance(rec, ownedPkSet(ident?.devices || []).has(String(rec?.devicePk || rec?.pk || '').trim())))
@@ -4954,7 +4829,7 @@ function startSharedRelayPipe(client, initialRelayUrls) {
         urls: relayUrls,
         relays: relayDetails,
       });
-      if (clientReady && relayBridgeOwner) {
+      if (bootRefreshSettled && clientReady && relayBridgeOwner) {
         client.call('relay.status', {
           state: msg.state,
           url: msg.url || '',
@@ -4962,7 +4837,7 @@ function startSharedRelayPipe(client, initialRelayUrls) {
           relays: relayDetails,
           code: msg.code ?? null,
           reason: msg.reason ?? ''
-        }, { timeoutMs: 20000, priority: 'immediate' }).catch((e) => console.error('relay.status rpc failed', e));
+        }, { timeoutMs: 20000 }).catch((e) => console.error('relay.status rpc failed', e));
       }
       return;
     }
@@ -4971,8 +4846,10 @@ function startSharedRelayPipe(client, initialRelayUrls) {
       if (gatewayPayload) {
         handleGatewayRelayPayload(gatewayPayload);
       }
-      if (clientReady && relayBridgeOwner) {
-        client.call('relay.rx', { data: msg.data, url: msg.url || '' }, { timeoutMs: 20000, priority: 'immediate' })
+      // During boot, let the shell recover local identity/device state first.
+      // Once boot settles, relay ingress can flow back into the SW queue.
+      if (bootRefreshSettled && clientReady && relayBridgeOwner) {
+        client.call('relay.rx', { data: msg.data, url: msg.url || '' }, { timeoutMs: 20000 })
           .catch((e) => console.error('relay.rx rpc failed', e));
       }
     }
@@ -5057,8 +4934,26 @@ function startSharedRelayPipe(client, initialRelayUrls) {
   startRelayBridgeHeartbeat();
   startRelayRuntime('init');
   updateTargets(initialRelayUrls, 'init');
+
+  function flushBootState() {
+    if (!clientReady || !relayBridgeOwner) return;
+    const relayUrls = Array.isArray(relayPoolSnapshot?.urls) ? relayPoolSnapshot.urls : [];
+    const relayDetails = (relayPoolSnapshot?.relays && typeof relayPoolSnapshot.relays === 'object')
+      ? relayPoolSnapshot.relays
+      : {};
+    client.call('relay.status', {
+      state: relayPoolSnapshot?.state || relayState,
+      url: '',
+      urls: relayUrls,
+      relays: relayDetails,
+      code: null,
+      reason: relayPoolSnapshot?.reason || '',
+    }, { timeoutMs: 20000 }).catch((e) => console.error('relay.status rpc failed', e));
+  }
+
   return {
     updateTargets,
+    flushBootState,
     close: () => teardownRelayRuntime('api-close'),
   };
 }
@@ -5118,8 +5013,6 @@ function startSharedRelayPipe(client, initialRelayUrls) {
   }
 
   loadGatewayExtraZones();
-  cleanupManagedLaunchContexts();
-  ensureManagedAppChannel();
   wireUi();
   await hydrateAppCatalog();
   renderConnectionModel('init');
@@ -5142,6 +5035,9 @@ function startSharedRelayPipe(client, initialRelayUrls) {
     showActivity('onboarding');
     setOnboardStep(1);
   } finally {
+    bootRefreshSettled = true;
+    relayBridge?.flushBootState?.();
+    scheduleRefreshAll(0);
     dismissBootSplash();
   }
 

--- a/app/managed-appliances.js
+++ b/app/managed-appliances.js
@@ -346,6 +346,8 @@ export function createManagedApplianceModel({
     applianceList,
     identityDevices,
     swarmDevices,
+    applianceRecords = null,
+    ownedDevicePks = null,
     gatewayInventoryStableAt,
     showActivity,
     setSettingsTab,
@@ -359,6 +361,7 @@ export function createManagedApplianceModel({
     launchNvrControlPanel,
     openGatewayBasicsModal,
     escapeHtml,
+    describeResourceName = null,
     getManagedServiceActionState = () => null,
     grantedRecords: providedGrantedRecords = [],
     getGrantInventoryForService = () => null,
@@ -368,8 +371,12 @@ export function createManagedApplianceModel({
     if (!applianceList) return;
     while (applianceList.firstChild) applianceList.firstChild.remove();
 
-    const owned = ownedPkSet(identityDevices);
-    const recs = buildApplianceRecords(identityDevices, swarmDevices, providedGrantedRecords);
+    const owned = Array.isArray(ownedDevicePks)
+      ? new Set(ownedDevicePks.map((value) => String(value || '').trim()).filter(Boolean))
+      : ownedPkSet(identityDevices);
+    const recs = Array.isArray(applianceRecords)
+      ? applianceRecords.slice()
+      : buildApplianceRecords(identityDevices, swarmDevices, providedGrantedRecords);
     const { ownedRecords, grantedRecords, discoverableRecords } = partitionApplianceRecords(
       recs,
       owned,
@@ -406,8 +413,19 @@ export function createManagedApplianceModel({
       const kind = info.deviceKind ? `type ${info.deviceKind}` : '';
       const releaseMeta = formatReleaseMeta(info.releaseChannel, info.releaseTrack, info.releaseBranch);
       const releaseLine = releaseMeta ? `<div class="itemMeta">release ${escapeHtml(releaseMeta)}</div>` : '';
+      const gatewayDescriptor = typeof describeResourceName === 'function'
+        ? describeResourceName(info.hostGatewayPk, shortPk(info.hostGatewayPk))
+        : null;
       const hostGatewayLine = info.hostGatewayPk
-        ? `<div class="itemMeta">host gateway ${escapeHtml(info.hostGatewayPk.slice(0, 16))}…</div>`
+        ? (() => {
+            if (gatewayDescriptor?.loading) {
+              return '<div class="itemMeta">host gateway name loading…</div>';
+            }
+            if (gatewayDescriptor?.raw) {
+              return `<div class="itemMeta">host gateway id ${escapeHtml(gatewayDescriptor.text)}</div>`;
+            }
+            return `<div class="itemMeta">host gateway ${escapeHtml(gatewayDescriptor?.text || shortPk(info.hostGatewayPk))}</div>`;
+          })()
         : '';
       const hostedServicesLine = canSeeHostedServiceDetail && Array.isArray(info.hostedServices) && info.hostedServices.length > 0
         ? `<div class="itemMeta">hosted services ${escapeHtml(info.hostedServices.map((svc) => String(svc?.service || 'service')).join(', '))}</div>`
@@ -427,7 +445,7 @@ export function createManagedApplianceModel({
         : '';
       meta.innerHTML = `
         <div class="itemTitle">${escapeHtml(info.title)}</div>
-        <div class="itemMeta">pk ${escapeHtml(info.pk.slice(0, 16))}…</div>
+        <div class="itemMeta">id ${escapeHtml(shortPk(info.pk))}</div>
         <div class="itemMeta">${escapeHtml([kind, `role ${info.role}`, `service ${info.service}${suffix}`, host ? host.replace(/^ • /, '') : ''].filter(Boolean).join(' • '))}</div>
         ${hostGatewayLine}
         ${hostedServicesLine}

--- a/identity/sw/idb.js
+++ b/identity/sw/idb.js
@@ -61,6 +61,15 @@ async function backupGet(key) {
   }
 }
 
+async function backupDelete(key) {
+  try {
+    const cache = await caches.open(BACKUP_CACHE);
+    await cache.delete(backupRequestForKey(key));
+  } catch {
+    // backup is best-effort only
+  }
+}
+
 export async function kvGet(key) {
   try {
     const value = await withDbRetry(`kvGet(${String(key || '')})`, async (db) => await new Promise((resolve, reject) => {
@@ -96,4 +105,14 @@ export async function kvSet(key, value) {
     tx.onerror = () => reject(tx.error);
   }));
   await backupSet(key, value);
+}
+
+export async function kvDelete(key) {
+  await withDbRetry(`kvDelete(${String(key || '')})`, async (db) => await new Promise((resolve, reject) => {
+    const tx = db.transaction('kv', 'readwrite');
+    tx.objectStore('kv').delete(key);
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+  }));
+  await backupDelete(key);
 }

--- a/index.html
+++ b/index.html
@@ -11,8 +11,8 @@
 <div id="bootSplash" aria-live="polite" role="status">
   <div class="bootSplashCard">
     <div class="bootSpinner" aria-hidden="true"></div>
-    <p id="bootSplashTitle" class="bootSplashTitle">Connecting</p>
-    <p id="bootSplashStatus" class="bootSplashStatus">Bringing your identity and services online.</p>
+    <p id="bootSplashTitle" class="bootSplashTitle">Loading</p>
+    <p id="bootSplashStatus" class="bootSplashStatus" hidden></p>
   </div>
 </div>
 <header class="topbar">
@@ -79,17 +79,17 @@
   <section id="viewHome" class="activity hidden">
     <h1>Home</h1>
     <div class="card">
-      <div class="cardTitle">Identity summary</div>
+      <div class="cardTitle">Account</div>
       <div class="kv">
-        <div class="k">This device</div>
+        <div class="k">Device</div>
         <div class="v" id="deviceDidSummary"></div>
       </div>
       <div class="kv">
-        <div class="k">Security</div>
+        <div class="k">Protection</div>
         <div class="v" id="deviceSecuritySummary"></div>
       </div>
       <div class="kv">
-        <div class="k">Linked</div>
+        <div class="k">Signed in</div>
         <div class="v" id="identityLinkedSummary"></div>
       </div>
     </div>
@@ -148,11 +148,10 @@
       </section>
 
       <section>
-        <h2>Devices and Services</h2>
-        <div class="small muted">Owned resources, shared access, and discoverable infrastructure.</div>
+        <h2>Resources</h2>
         <div id="gatewayInstallStatus" class="small muted hidden u-mt-sm"></div>
         <div class="card">
-          <div class="cardTitle">Connected Devices and Services</div>
+          <div class="cardTitle">Resources</div>
           <div id="applianceList" class="list"></div>
         </div>
       </section>
@@ -164,7 +163,7 @@
       <h2>Network</h2>
 
       <div class="card">
-        <div class="cardTitle">Connection Summary</div>
+        <div class="cardTitle">Status</div>
         <div class="kv">
           <div class="k">Connection</div>
           <div class="v" id="networkStatusConnection">offline</div>
@@ -181,7 +180,7 @@
           <div class="k">Services</div>
           <div class="v" id="networkStatusServices">unknown</div>
         </div>
-        <div class="small muted" id="networkStatusDetail">Connection details also live in the drawer footer.</div>
+        <div class="small muted" id="networkStatusDetail">Updates automatically.</div>
       </div>
 
       <div class="card">

--- a/runtime.worker.js
+++ b/runtime.worker.js
@@ -1,24 +1,121 @@
-const RUNTIME_WORKER_BUILD_ID = '2026-04-03-runtime-v1';
+const RUNTIME_VERSION = Object.freeze({ major: 2, minor: 8 });
+const RUNTIME_WORKER_BUILD_ID = `runtime-${RUNTIME_VERSION.major}.${RUNTIME_VERSION.minor}`;
 const CONTEXT_TTL_FALLBACK_MS = 2 * 60 * 1000;
+const APPLIANCE_DISCOVERY_MAX_AGE_MS = 60 * 60 * 1000;
+const RUNTIME_STATE_KEY = `runtime.shared.state.v${RUNTIME_VERSION.major}`;
+const RUNTIME_META_KEY = `runtime.shared.meta.v${RUNTIME_VERSION.major}`;
+
+const DB_NAME = 'constitute_db';
+const DB_VER = 1;
+
+function openDB() {
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.open(DB_NAME, DB_VER);
+    req.onupgradeneeded = () => {
+      const db = req.result;
+      if (!db.objectStoreNames.contains('kv')) db.createObjectStore('kv');
+    };
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error);
+  });
+}
+
+async function withDbRetry(label, work, attempts = 2) {
+  let lastError = null;
+  for (let index = 0; index < attempts; index += 1) {
+    try {
+      const db = await openDB();
+      return await work(db);
+    } catch (error) {
+      lastError = error;
+      if (index < attempts - 1) {
+        await new Promise((resolve) => setTimeout(resolve, 30 * (index + 1)));
+      }
+    }
+  }
+  throw new Error(`${label}: ${String(lastError?.message || lastError || 'database failure')}`);
+}
+
+async function kvGet(key) {
+  return await withDbRetry(`kvGet(${String(key || '')})`, async (db) => await new Promise((resolve, reject) => {
+    const tx = db.transaction('kv', 'readonly');
+    const st = tx.objectStore('kv');
+    const req = st.get(key);
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error);
+  }));
+}
+
+async function kvSet(key, value) {
+  await withDbRetry(`kvSet(${String(key || '')})`, async (db) => await new Promise((resolve, reject) => {
+    const tx = db.transaction('kv', 'readwrite');
+    tx.objectStore('kv').put(value, key);
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+  }));
+}
+
+async function kvDelete(key) {
+  await withDbRetry(`kvDelete(${String(key || '')})`, async (db) => await new Promise((resolve, reject) => {
+    const tx = db.transaction('kv', 'readwrite');
+    tx.objectStore('kv').delete(key);
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+  }));
+}
+
+function normalizeRole(value) {
+  return String(value || '').trim().toLowerCase();
+}
+
+function isGatewayRecord(rec) {
+  const role = normalizeRole(rec?.role || rec?.nodeType || rec?.type || '');
+  const service = normalizeRole(rec?.service || '');
+  return role === 'gateway' || service === 'gateway';
+}
+
+function isNvrRecord(rec) {
+  const role = normalizeRole(rec?.role || rec?.nodeType || rec?.type || '');
+  const service = normalizeRole(rec?.service || '');
+  return role === 'nvr' || service === 'nvr';
+}
+
+function ownedPkSet(identityDevices) {
+  return new Set(
+    (Array.isArray(identityDevices) ? identityDevices : [])
+      .map((d) => String(d?.pk || d?.devicePk || '').trim())
+      .filter(Boolean),
+  );
+}
 
 const endpoints = new Map();
-const launchContexts = new Map();
 const pendingBrokerRequests = new Map();
-const projectionStore = {
-  discoverable: new Map(),
-  owned: new Map(),
-  granted: new Map(),
-  session: new Map(),
-};
+const launchContexts = new Map();
 const runtimeStatus = {
-  buildId: RUNTIME_WORKER_BUILD_ID,
-  updatedAt: 0,
   shell: null,
   services: {},
 };
+const managedState = {
+  sourceSnapshot: {
+    identityDevices: [],
+    swarmDevices: [],
+    grantedRecords: [],
+    managedServiceIssue: null,
+  },
+  applianceSnapshot: {
+    owned: [],
+    granted: [],
+    discoverable: [],
+  },
+  resourceNames: {},
+  managedServiceIssue: null,
+  hostedGatewaySnapshots: {},
+};
 
 let brokerClientId = '';
-let dedicatedEndpoint = null;
+let runtimeUpdatedAt = 0;
+let hydratePromise = null;
+let persistTimer = 0;
 
 function nowMs() {
   return Date.now();
@@ -33,49 +130,352 @@ function safeClone(value) {
   }
 }
 
-function projectionCategoryMap(category) {
-  const key = String(category || '').trim().toLowerCase();
-  return projectionStore[key] || null;
+function isLocalhostRuntime() {
+  try {
+    const host = String(self.location?.hostname || '').trim().toLowerCase();
+    return host === 'localhost' || host === '127.0.0.1';
+  } catch {
+    return false;
+  }
 }
 
-function cloneProjectionStore() {
-  const out = {};
-  for (const [category, store] of Object.entries(projectionStore)) {
-    out[category] = Object.fromEntries(Array.from(store.entries()).map(([key, value]) => [key, safeClone(value)]));
+function normalizeArray(value) {
+  return Array.isArray(value) ? value : [];
+}
+
+function normalizeObject(value) {
+  return (value && typeof value === 'object') ? value : {};
+}
+
+function touchRuntime() {
+  runtimeUpdatedAt = nowMs();
+}
+
+function managedLaunchContextObject() {
+  return Object.fromEntries(Array.from(launchContexts.entries()).map(([launchId, context]) => [launchId, safeClone(context)]));
+}
+
+function normalizeHostedServices(value) {
+  if (!Array.isArray(value)) return [];
+  return value
+    .map((entry) => (entry && typeof entry === 'object') ? safeClone(entry) : null)
+    .filter(Boolean);
+}
+
+function gatewayHostedSnapshot(record) {
+  const pk = String(record?.devicePk || record?.pk || '').trim();
+  const updatedAt = Number(record?.updatedAt || record?.updated_at || record?.ts || 0);
+  const hostedServices = normalizeHostedServices(record?.hostedServices || record?.hosted_services);
+  return { pk, updatedAt, hostedServices };
+}
+
+function applyGatewayHostedSnapshot(record) {
+  const role = String(record?.role || record?.nodeType || record?.type || '').trim().toLowerCase();
+  const service = String(record?.service || '').trim().toLowerCase();
+  const isGateway = role === 'gateway' || service === 'gateway';
+  if (!isGateway) return record;
+
+  const current = gatewayHostedSnapshot(record);
+  if (!current.pk) return record;
+
+  const cache = normalizeObject(managedState.hostedGatewaySnapshots);
+  const cached = cache[current.pk] && typeof cache[current.pk] === 'object' ? cache[current.pk] : null;
+  let effectiveHostedServices = current.hostedServices;
+
+  if (effectiveHostedServices.length > 0) {
+    cache[current.pk] = {
+      updatedAt: current.updatedAt,
+      hostedServices: effectiveHostedServices,
+    };
+    managedState.hostedGatewaySnapshots = cache;
+  } else if (cached && Array.isArray(cached.hostedServices) && cached.hostedServices.length > 0) {
+    const cachedUpdatedAt = Number(cached.updatedAt || 0);
+    if (cachedUpdatedAt >= current.updatedAt) {
+      effectiveHostedServices = cached.hostedServices;
+    } else if (current.updatedAt >= cachedUpdatedAt) {
+      cache[current.pk] = {
+        updatedAt: current.updatedAt,
+        hostedServices: [],
+      };
+      managedState.hostedGatewaySnapshots = cache;
+    }
   }
-  return out;
+
+  if (effectiveHostedServices === current.hostedServices) return record;
+  return {
+    ...record,
+    hostedServices: effectiveHostedServices,
+  };
+}
+
+function getSwarmSeenAt(pk) {
+  const target = String(pk || '').trim();
+  if (!target) return 0;
+  for (const record of normalizeArray(managedState.sourceSnapshot?.swarmDevices)) {
+    const devicePk = String(record?.devicePk || record?.pk || '').trim();
+    if (devicePk !== target) continue;
+    return Number(record?.updatedAt || record?.updated_at || record?.ts || record?.lastSeen || 0);
+  }
+  return 0;
+}
+
+function applianceSeenAt(rec) {
+  if (String(rec?.managedAvailabilityAuthority || '').trim().toLowerCase() === 'gateway') {
+    const authoritativeSeen = Number(
+      rec?.managedAvailabilityUpdatedAt
+      || rec?.managed_availability_updated_at
+      || rec?.updatedAt
+      || rec?.updated_at
+      || 0,
+    );
+    return Math.max(0, authoritativeSeen);
+  }
+  const pk = String(rec?.devicePk || rec?.pk || '').trim();
+  const nostrSeen = Number(rec?.updatedAt || rec?.updated_at || rec?.ts || rec?.lastSeen || 0);
+  const swarmSeen = pk ? Number(getSwarmSeenAt(pk) || 0) : 0;
+  const hostedSeen = Array.isArray(rec?.hostedServices || rec?.hosted_services)
+    ? (rec.hostedServices || rec.hosted_services).reduce((latest, hosted) => {
+        const hostedUpdatedAt = Number(hosted?.updatedAt || hosted?.updated_at || 0);
+        return Math.max(latest, hostedUpdatedAt);
+      }, 0)
+    : 0;
+  return Math.max(0, nostrSeen, swarmSeen, hostedSeen);
+}
+
+function effectiveApplianceSeenAt(rec, allRecords = []) {
+  const baseSeen = applianceSeenAt(rec);
+  if (!isGatewayRecord(rec)) return baseSeen;
+  const gatewayPk = String(rec?.devicePk || rec?.pk || '').trim();
+  if (!gatewayPk) return baseSeen;
+  let hostedSeen = 0;
+  for (const candidate of Array.isArray(allRecords) ? allRecords : []) {
+    if (!isNvrRecord(candidate)) continue;
+    const hostGatewayPk = String(candidate?.hostGatewayPk || candidate?.host_gateway_pk || '').trim();
+    if (!hostGatewayPk || hostGatewayPk !== gatewayPk) continue;
+    hostedSeen = Math.max(hostedSeen, applianceSeenAt(candidate));
+  }
+  return Math.max(baseSeen, hostedSeen);
+}
+
+function mergeGatewayHostedServiceRecord(actualRecord, hostedRecord, gatewayRecord) {
+  const actual = (actualRecord && typeof actualRecord === 'object') ? actualRecord : {};
+  const hosted = (hostedRecord && typeof hostedRecord === 'object') ? hostedRecord : {};
+  const gateway = (gatewayRecord && typeof gatewayRecord === 'object') ? gatewayRecord : {};
+  const gatewayPk = String(
+    hosted.hostGatewayPk
+    || hosted.host_gateway_pk
+    || gateway.devicePk
+    || gateway.pk
+    || actual.hostGatewayPk
+    || actual.host_gateway_pk
+    || '',
+  ).trim();
+  const hostedUpdatedAt = Number(hosted.updatedAt || hosted.updated_at || gateway.updatedAt || gateway.updated_at || 0);
+  return {
+    ...actual,
+    devicePk: String(hosted.devicePk || hosted.device_pk || actual.devicePk || actual.pk || '').trim(),
+    deviceLabel: String(hosted.deviceLabel || hosted.device_label || actual.deviceLabel || actual.label || hosted.service || 'service').trim(),
+    deviceKind: String(hosted.deviceKind || hosted.device_kind || actual.deviceKind || actual.device_kind || 'service').trim() || 'service',
+    role: String(hosted.service || actual.role || actual.nodeType || actual.type || '').trim(),
+    service: String(hosted.service || actual.service || '').trim(),
+    hostGatewayPk: gatewayPk,
+    serviceVersion: String(hosted.serviceVersion || hosted.service_version || actual.serviceVersion || actual.service_version || '').trim(),
+    updatedAt: hostedUpdatedAt,
+    freshnessMs: Number(hosted.freshnessMs || hosted.freshness_ms || actual.freshnessMs || actual.freshness_ms || 0),
+    status: String(hosted.status || actual.status || '').trim(),
+    cameraCount: Number(hosted.cameraCount || hosted.camera_count || actual.cameraCount || actual.camera_count || 0),
+    managedAvailabilityAuthority: 'gateway',
+    managedAvailabilityUpdatedAt: hostedUpdatedAt,
+    managedAvailabilityGatewayPk: gatewayPk,
+    directServiceUpdatedAt: Number(actual.updatedAt || actual.updated_at || actual.ts || actual.lastSeen || 0),
+    hostedSynthetic: Boolean(actual.hostedSynthetic),
+  };
+}
+
+function buildApplianceRecords(identityDevices, swarmDevices, grantedRecords = []) {
+  const owned = ownedPkSet(identityDevices);
+  const actual = [];
+  const seen = new Set();
+  const sourceRecords = Array.isArray(swarmDevices) ? swarmDevices : [];
+  for (const rawRec of sourceRecords) {
+    const rec = applyGatewayHostedSnapshot(rawRec);
+    const pk = String(rec?.devicePk || rec?.pk || '').trim();
+    if (!pk || seen.has(pk)) continue;
+    if (!(isGatewayRecord(rec) || isNvrRecord(rec))) continue;
+    const ownedRec = owned.has(pk) || owned.has(String(rec?.hostGatewayPk || rec?.host_gateway_pk || '').trim());
+    const seenAt = applianceSeenAt(rec);
+    const ageMs = seenAt ? Math.max(0, Date.now() - seenAt) : Number.POSITIVE_INFINITY;
+    if (!ownedRec && ageMs > APPLIANCE_DISCOVERY_MAX_AGE_MS) continue;
+    seen.add(pk);
+    actual.push(rec);
+  }
+
+  const actualByPk = new Map(actual.map((rec) => [String(rec?.devicePk || rec?.pk || '').trim(), rec]).filter(([pk]) => pk));
+  const recs = [...actual];
+  const actualPkSet = new Set(actualByPk.keys());
+  for (const rec of actual) {
+    if (!isGatewayRecord(rec)) continue;
+    const hostedServices = Array.isArray(rec?.hostedServices || rec?.hosted_services)
+      ? (rec.hostedServices || rec.hosted_services)
+      : [];
+    for (const hosted of hostedServices) {
+      const pk = String(hosted?.devicePk || hosted?.device_pk || '').trim();
+      if (!pk) continue;
+      const merged = mergeGatewayHostedServiceRecord(actualByPk.get(pk), hosted, rec);
+      if (actualByPk.has(pk)) {
+        const idx = recs.findIndex((candidate) => String(candidate?.devicePk || candidate?.pk || '').trim() === pk);
+        if (idx >= 0) recs[idx] = merged;
+        actualByPk.set(pk, merged);
+        continue;
+      }
+      recs.push({
+        ...merged,
+        hostedSynthetic: true,
+      });
+      actualByPk.set(pk, merged);
+      actualPkSet.add(pk);
+    }
+  }
+
+  recs.sort((a, b) => Number(effectiveApplianceSeenAt(b, recs) || 0) - Number(effectiveApplianceSeenAt(a, recs) || 0));
+  for (const granted of Array.isArray(grantedRecords) ? grantedRecords : []) {
+    const pk = String(granted?.devicePk || granted?.pk || '').trim();
+    if (!pk || actualPkSet.has(pk)) continue;
+    recs.push({
+      ...granted,
+      grantedRecord: true,
+    });
+    actualPkSet.add(pk);
+  }
+  recs.sort((a, b) => Number(effectiveApplianceSeenAt(b, recs) || 0) - Number(effectiveApplianceSeenAt(a, recs) || 0));
+  return recs;
+}
+
+function partitionApplianceRecords(recs, owned, isGrantedRecord) {
+  const ownedRecords = [];
+  const grantedRecords = [];
+  const discoverableRecords = [];
+
+  for (const rec of recs) {
+    const pk = String(rec?.devicePk || rec?.pk || '').trim();
+    const ownedRec = owned.has(pk) || owned.has(String(rec?.hostGatewayPk || rec?.host_gateway_pk || '').trim());
+    if (ownedRec) {
+      ownedRecords.push(rec);
+      continue;
+    }
+    if (isGrantedRecord(rec)) {
+      grantedRecords.push(rec);
+      continue;
+    }
+    if (isGatewayRecord(rec)) {
+      discoverableRecords.push(rec);
+    }
+  }
+
+  return {
+    ownedRecords,
+    grantedRecords,
+    discoverableRecords,
+  };
+}
+
+function rememberResourceName(map, pk, label) {
+  const key = String(pk || '').trim();
+  const text = String(label || '').trim();
+  if (!key || !text) return;
+  map[key] = text;
+}
+
+function buildResourceNames() {
+  const names = {};
+  for (const identityDevice of normalizeArray(managedState.sourceSnapshot?.identityDevices)) {
+    rememberResourceName(
+      names,
+      identityDevice?.pk || identityDevice?.devicePk || identityDevice?.identityId,
+      identityDevice?.label || identityDevice?.deviceLabel || identityDevice?.name,
+    );
+  }
+  for (const bucket of Object.values(managedState.applianceSnapshot)) {
+    for (const record of normalizeArray(bucket)) {
+      rememberResourceName(
+        names,
+        record?.devicePk || record?.pk,
+        record?.deviceLabel || record?.label || record?.serviceLabel || record?.name,
+      );
+      rememberResourceName(
+        names,
+        record?.hostGatewayPk || record?.host_gateway_pk,
+        record?.hostGatewayLabel || record?.host_gateway_label,
+      );
+    }
+  }
+  return names;
+}
+
+function normalizeManagedSourceSnapshot(snapshot) {
+  const payload = normalizeObject(snapshot);
+  return {
+    identityDevices: normalizeArray(payload.identityDevices).map((entry) => safeClone(entry)),
+    swarmDevices: normalizeArray(payload.swarmDevices).map((entry) => safeClone(entry)),
+    grantedRecords: normalizeArray(payload.grantedRecords).map((entry) => safeClone(entry)),
+    managedServiceIssue: payload.managedServiceIssue ? safeClone(payload.managedServiceIssue) : null,
+  };
+}
+
+function rebuildManagedApplianceSnapshot() {
+  const source = managedState.sourceSnapshot;
+  const identityDevices = normalizeArray(source.identityDevices);
+  const swarmDevices = normalizeArray(source.swarmDevices);
+  const grantedRecords = normalizeArray(source.grantedRecords);
+  const combined = buildApplianceRecords(identityDevices, swarmDevices, grantedRecords);
+  const owned = ownedPkSet(identityDevices);
+  const partitions = partitionApplianceRecords(
+    combined,
+    owned,
+    (record) => record?.sharedProjection === true || record?.grantedRecord === true,
+  );
+  managedState.applianceSnapshot = {
+    owned: safeClone(partitions.ownedRecords),
+    granted: safeClone(partitions.grantedRecords),
+    discoverable: safeClone(partitions.discoverableRecords),
+  };
+  managedState.resourceNames = buildResourceNames();
+  managedState.managedServiceIssue = source.managedServiceIssue ? safeClone(source.managedServiceIssue) : null;
 }
 
 function cleanupLaunchContexts() {
   const now = nowMs();
+  let changed = false;
   for (const [launchId, context] of launchContexts.entries()) {
     const expiresAt = Number(context?.expiresAt || 0) || (Number(context?.createdAt || 0) + CONTEXT_TTL_FALLBACK_MS);
     if (expiresAt && expiresAt <= now) {
       launchContexts.delete(launchId);
+      changed = true;
     }
   }
+  return changed;
 }
 
 function runtimeSnapshot() {
-  cleanupLaunchContexts();
+  if (cleanupLaunchContexts()) {
+    touchRuntime();
+    schedulePersist();
+  }
   return {
     buildId: RUNTIME_WORKER_BUILD_ID,
-    updatedAt: runtimeStatus.updatedAt || nowMs(),
-    brokerClientId,
+    updatedAt: runtimeUpdatedAt || nowMs(),
     shell: safeClone(runtimeStatus.shell),
     services: safeClone(runtimeStatus.services),
+    managedAppliances: safeClone(managedState.applianceSnapshot),
+    resourceNames: safeClone(managedState.resourceNames),
+    managedServiceIssue: safeClone(managedState.managedServiceIssue),
     launchContextCount: launchContexts.size,
-    projections: cloneProjectionStore(),
   };
 }
 
 function endpointPost(endpoint, message) {
   try {
-    if (endpoint.kind === 'shared') {
-      endpoint.port.postMessage(message);
-      return;
-    }
-    self.postMessage(message);
+    endpoint?.port?.postMessage(message);
   } catch {}
 }
 
@@ -88,7 +488,8 @@ function broadcast(message) {
 function broadcastSnapshot() {
   const snapshot = runtimeSnapshot();
   broadcast({
-    type: 'status.snapshot',
+    type: 'runtime.snapshot',
+    buildId: RUNTIME_WORKER_BUILD_ID,
     snapshot,
   });
 }
@@ -123,18 +524,119 @@ function deleteEndpoint(clientId) {
   }
 }
 
-function handleStatusUpdate(message, endpoint) {
+function serializedRuntimeState() {
+  return {
+    buildId: RUNTIME_WORKER_BUILD_ID,
+    updatedAt: runtimeUpdatedAt || nowMs(),
+    shell: safeClone(runtimeStatus.shell),
+    services: safeClone(runtimeStatus.services),
+    managedAppliancesSource: safeClone(managedState.sourceSnapshot),
+    managedAppliances: safeClone(managedState.applianceSnapshot),
+    resourceNames: safeClone(managedState.resourceNames),
+    managedServiceIssue: safeClone(managedState.managedServiceIssue),
+    hostedGatewaySnapshots: safeClone(managedState.hostedGatewaySnapshots),
+    launchContexts: managedLaunchContextObject(),
+  };
+}
+
+async function clearPersistedState() {
+  await Promise.all([
+    kvDelete(RUNTIME_STATE_KEY).catch(() => {}),
+    kvDelete(RUNTIME_META_KEY).catch(() => {}),
+  ]);
+}
+
+async function persistRuntimeState() {
+  const payload = serializedRuntimeState();
+  await Promise.all([
+    kvSet(RUNTIME_STATE_KEY, payload),
+    kvSet(RUNTIME_META_KEY, {
+      buildId: RUNTIME_WORKER_BUILD_ID,
+      schemaVersion: RUNTIME_VERSION.major,
+      updatedAt: payload.updatedAt,
+    }),
+  ]);
+}
+
+function schedulePersist() {
+  if (persistTimer) return;
+  persistTimer = self.setTimeout(() => {
+    persistTimer = 0;
+    void persistRuntimeState().catch(() => {});
+  }, 0);
+}
+
+async function hydrateRuntimeState() {
+  const meta = await kvGet(RUNTIME_META_KEY).catch(() => null);
+  const schemaVersion = Number(meta?.schemaVersion || RUNTIME_VERSION.major);
+  if (isLocalhostRuntime() && String(meta?.buildId || '').trim() && schemaVersion !== RUNTIME_VERSION.major) {
+    await clearPersistedState();
+  }
+  const persisted = await kvGet(RUNTIME_STATE_KEY).catch(() => null);
+  if (persisted && typeof persisted === 'object') {
+    const payload = persisted;
+    runtimeUpdatedAt = Number(payload.updatedAt || 0);
+    runtimeStatus.shell = payload.shell && typeof payload.shell === 'object' ? safeClone(payload.shell) : null;
+    runtimeStatus.services = payload.services && typeof payload.services === 'object' ? safeClone(payload.services) : {};
+    managedState.sourceSnapshot = normalizeManagedSourceSnapshot(payload.managedAppliancesSource);
+    managedState.applianceSnapshot = payload.managedAppliances && typeof payload.managedAppliances === 'object'
+      ? {
+          owned: normalizeArray(payload.managedAppliances.owned).map((entry) => safeClone(entry)),
+          granted: normalizeArray(payload.managedAppliances.granted).map((entry) => safeClone(entry)),
+          discoverable: normalizeArray(payload.managedAppliances.discoverable).map((entry) => safeClone(entry)),
+        }
+      : {
+          owned: [],
+          granted: [],
+          discoverable: [],
+        };
+    managedState.resourceNames = payload.resourceNames && typeof payload.resourceNames === 'object'
+      ? safeClone(payload.resourceNames)
+      : {};
+    managedState.managedServiceIssue = payload.managedServiceIssue ? safeClone(payload.managedServiceIssue) : null;
+    managedState.hostedGatewaySnapshots = payload.hostedGatewaySnapshots && typeof payload.hostedGatewaySnapshots === 'object'
+      ? safeClone(payload.hostedGatewaySnapshots)
+      : {};
+    launchContexts.clear();
+    const persistedContexts = payload.launchContexts && typeof payload.launchContexts === 'object'
+      ? payload.launchContexts
+      : {};
+    for (const [launchId, context] of Object.entries(persistedContexts)) {
+      const key = String(launchId || '').trim();
+      if (!key || !context || typeof context !== 'object') continue;
+      launchContexts.set(key, safeClone(context));
+    }
+  }
+  rebuildManagedApplianceSnapshot();
+  if (cleanupLaunchContexts()) {
+    touchRuntime();
+    schedulePersist();
+  }
+}
+
+function ensureHydrated() {
+  if (!hydratePromise) {
+    hydratePromise = hydrateRuntimeState().catch((error) => {
+      hydratePromise = null;
+      throw error;
+    });
+  }
+  return hydratePromise;
+}
+
+function handleStatusPut(message, endpoint) {
   const role = String(message.role || message.surface || endpoint?.surface || '').trim().toLowerCase();
   const payload = message.status && typeof message.status === 'object' ? message.status : {};
-  runtimeStatus.updatedAt = nowMs();
+  touchRuntime();
 
   if (role === 'shell') {
     runtimeStatus.shell = {
       ...safeClone(payload),
-      updatedAt: runtimeStatus.updatedAt,
+      updatedAt: runtimeUpdatedAt,
     };
+    schedulePersist();
     broadcastSnapshot();
-    return { ok: true };
+    return { ok: true, result: runtimeSnapshot() };
   }
 
   const service = String(message.service || payload.service || endpoint?.surface || '').trim().toLowerCase();
@@ -144,10 +646,11 @@ function handleStatusUpdate(message, endpoint) {
   runtimeStatus.services[service] = {
     ...safeClone(payload),
     service,
-    updatedAt: runtimeStatus.updatedAt,
+    updatedAt: runtimeUpdatedAt,
   };
+  schedulePersist();
   broadcastSnapshot();
-  return { ok: true };
+  return { ok: true, result: runtimeSnapshot() };
 }
 
 function handleLaunchContextPut(message) {
@@ -156,35 +659,38 @@ function handleLaunchContextPut(message) {
   if (!launchId) return { ok: false, error: 'missing launchId' };
   launchContexts.set(launchId, safeClone(context));
   cleanupLaunchContexts();
+  touchRuntime();
+  schedulePersist();
   broadcastSnapshot();
-  return { ok: true };
+  return { ok: true, result: safeClone(launchContexts.get(launchId) || null) };
 }
 
 function handleLaunchContextGet(message) {
   cleanupLaunchContexts();
   const launchId = String(message.launchId || '').trim();
   if (!launchId) return { ok: false, error: 'missing launchId' };
-  return { ok: true, result: launchContexts.get(launchId) || null };
+  return { ok: true, result: safeClone(launchContexts.get(launchId) || null) };
 }
 
-function handleProjectionPut(message) {
-  const category = String(message.category || '').trim().toLowerCase();
-  const key = String(message.key || '').trim();
-  const store = projectionCategoryMap(category);
-  if (!store) return { ok: false, error: 'unsupported projection category' };
-  if (!key) return { ok: false, error: 'missing projection key' };
-  store.set(key, safeClone(message.value));
+function handleLaunchContextDelete(message) {
+  const launchId = String(message.launchId || '').trim();
+  if (!launchId) return { ok: false, error: 'missing launchId' };
+  const existed = launchContexts.delete(launchId);
+  if (existed) {
+    touchRuntime();
+    schedulePersist();
+    broadcastSnapshot();
+  }
+  return { ok: true, result: { deleted: existed } };
+}
+
+function handleManagedSourceSnapshotPut(message) {
+  managedState.sourceSnapshot = normalizeManagedSourceSnapshot(message.sourceSnapshot);
+  rebuildManagedApplianceSnapshot();
+  touchRuntime();
+  schedulePersist();
   broadcastSnapshot();
-  return { ok: true };
-}
-
-function handleProjectionGet(message) {
-  const category = String(message.category || '').trim().toLowerCase();
-  const key = String(message.key || '').trim();
-  const store = projectionCategoryMap(category);
-  if (!store) return { ok: false, error: 'unsupported projection category' };
-  if (!key) return { ok: false, error: 'missing projection key' };
-  return { ok: true, result: safeClone(store.get(key) || null) };
+  return { ok: true, result: runtimeSnapshot() };
 }
 
 function forwardBrokerRequest(kind, message, endpoint) {
@@ -225,21 +731,14 @@ function handleBrokerResponse(kind, message) {
     error: String(message.error || '').trim(),
   };
   const endpoint = pending.requesterEndpoint || endpoints.get(pending.requesterId);
-  if (endpoint) {
-    endpointPost(endpoint, response);
-    return { ok: true };
-  }
-  let delivered = false;
-  for (const candidate of endpoints.values()) {
-    if (candidate.clientId === brokerClientId) continue;
-    endpointPost(candidate, response);
-    delivered = true;
-  }
-  if (delivered) return { ok: true, warning: 'broadcast fallback' };
-  return { ok: false, error: 'requester not attached' };
+  if (!endpoint) return { ok: false, error: 'requester not attached' };
+  endpointPost(endpoint, response);
+  return { ok: true };
 }
 
-function handleControlMessage(message, endpoint) {
+async function handleControlMessage(message, endpoint) {
+  await ensureHydrated();
+
   const type = String(message?.type || '').trim();
   if (!type) return;
 
@@ -256,7 +755,6 @@ function handleControlMessage(message, endpoint) {
         type: 'runtime.attached',
         buildId: RUNTIME_WORKER_BUILD_ID,
         clientId: entry?.clientId || '',
-        brokerClientId,
         snapshot: runtimeSnapshot(),
       };
       break;
@@ -266,23 +764,25 @@ function handleControlMessage(message, endpoint) {
       response = {
         type: 'runtime.detached',
         buildId: RUNTIME_WORKER_BUILD_ID,
-        brokerClientId,
       };
       break;
     }
-    case 'status.update': {
+    case 'runtime.snapshot.get': {
       response = {
         type: 'runtime.response',
         requestId: String(message.requestId || '').trim(),
-        kind: 'status.update',
-        ...handleStatusUpdate(message, endpoint),
+        kind: 'runtime.snapshot.get',
+        ok: true,
+        result: runtimeSnapshot(),
       };
       break;
     }
-    case 'status.snapshot': {
+    case 'runtime.status.put': {
       response = {
-        type: 'status.snapshot',
-        snapshot: runtimeSnapshot(),
+        type: 'runtime.response',
+        requestId: String(message.requestId || '').trim(),
+        kind: 'runtime.status.put',
+        ...handleStatusPut(message, endpoint),
       };
       break;
     }
@@ -304,43 +804,33 @@ function handleControlMessage(message, endpoint) {
       };
       break;
     }
-    case 'projection.put': {
+    case 'launchContext.delete': {
       response = {
         type: 'runtime.response',
         requestId: String(message.requestId || '').trim(),
-        kind: 'projection.put',
-        ...handleProjectionPut(message),
+        kind: 'launchContext.delete',
+        ...handleLaunchContextDelete(message),
       };
       break;
     }
-    case 'projection.get': {
+    case 'managedAppliances.sourceSnapshot.put': {
       response = {
         type: 'runtime.response',
         requestId: String(message.requestId || '').trim(),
-        kind: 'projection.get',
-        ...handleProjectionGet(message),
+        kind: 'managedAppliances.sourceSnapshot.put',
+        ...handleManagedSourceSnapshotPut(message),
       };
       break;
     }
-    case 'gateway.signal.request': {
-      const result = forwardBrokerRequest('gateway.signal.request', message, endpoint);
+    case 'gateway.signal.request':
+    case 'gateway.launch.request':
+    case 'gateway.grant.request': {
+      const result = forwardBrokerRequest(type, message, endpoint);
       if (!result.ok) {
         response = {
           type: 'runtime.response',
           requestId: String(message.requestId || '').trim(),
-          kind: 'gateway.signal.request',
-          ...result,
-        };
-      }
-      break;
-    }
-    case 'gateway.launch.request': {
-      const result = forwardBrokerRequest('gateway.launch.request', message, endpoint);
-      if (!result.ok) {
-        response = {
-          type: 'runtime.response',
-          requestId: String(message.requestId || '').trim(),
-          kind: 'gateway.launch.request',
+          kind: type,
           ...result,
         };
       }
@@ -362,7 +852,15 @@ function handleControlMessage(message, endpoint) {
       };
       break;
     }
-    default:
+    case 'gateway.grant.response': {
+      response = {
+        type: 'runtime.ack',
+        kind: 'gateway.grant.response',
+        ...handleBrokerResponse('gateway.grant.request', message),
+      };
+      break;
+    }
+    default: {
       response = {
         type: 'runtime.response',
         requestId: String(message.requestId || '').trim(),
@@ -371,37 +869,29 @@ function handleControlMessage(message, endpoint) {
         error: `unsupported runtime message: ${type}`,
       };
       break;
+    }
   }
 
   if (response) endpointPost(endpoint, response);
 }
 
 function attachSharedPort(port) {
-  const endpoint = { kind: 'shared', port, clientId: '' };
-  port.onmessage = (event) => handleControlMessage(event.data || {}, endpoint);
+  const endpoint = { port, clientId: '', broker: false, surface: '' };
+  port.onmessage = (event) => {
+    void handleControlMessage(event.data || {}, endpoint).catch((error) => {
+      endpointPost(endpoint, {
+        type: 'runtime.response',
+        requestId: String(event?.data?.requestId || '').trim(),
+        kind: String(event?.data?.type || '').trim(),
+        ok: false,
+        error: String(error?.message || error || 'runtime failure'),
+      });
+    });
+  };
   port.start();
-  endpointPost(endpoint, {
-    type: 'runtime.attached',
-    buildId: RUNTIME_WORKER_BUILD_ID,
-    clientId: '',
-    brokerClientId,
-    snapshot: runtimeSnapshot(),
-  });
-}
-
-function ensureDedicatedEndpoint() {
-  if (dedicatedEndpoint) return dedicatedEndpoint;
-  dedicatedEndpoint = { kind: 'dedicated', port: null, clientId: 'dedicated' };
-  endpoints.set(dedicatedEndpoint.clientId, dedicatedEndpoint);
-  return dedicatedEndpoint;
 }
 
 self.onconnect = (event) => {
   const port = event.ports?.[0];
   if (port) attachSharedPort(port);
 };
-
-self.addEventListener('message', (event) => {
-  const endpoint = ensureDedicatedEndpoint();
-  handleControlMessage(event.data || {}, endpoint);
-});


### PR DESCRIPTION
## Summary
- move managed launch, launch-context durability, and shared appliance projections under the shared runtime
- simplify shell ownership so managed surfaces consume runtime-shaped state instead of duplicating local truth
- keep browser startup and live-surface behavior aligned with the new runtime contract

## Verification
- npm run build
- npm test
