### PR TITLE
refactor(loading): make runtime snapshot the shell boot authority

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -98,6 +98,33 @@ Service Worker
 - WebRTC is the preferred browser-safe transport direction for managed live media and direct paths
 - shell launch/bootstrap must stay separate from media transport
 
+## Startup Model
+
+### First Paint Authority
+- shared runtime snapshot is the first-paint authority for the shell and same-origin first-party app surfaces
+- persisted runtime state may be stale, but it is preferred over blocking on live hydration
+- live refresh reconciles the shell and managed surfaces after first paint
+
+### Critical Boot Vs Background Hydration
+Critical boot is limited to:
+- shell/runtime attach
+- first available runtime snapshot
+- minimum surface structure for the shell or managed app
+
+Background hydration owns:
+- service worker/controller readiness
+- relay startup
+- identity/device refresh
+- directory, zone, swarm, and notification refresh
+- app catalog hydration
+- managed app signaling/media negotiation
+
+### Surface State Rules
+- service worker/controller readiness is infrastructure warming, not a page gate
+- the shell should not remain behind a full-page splash once runtime snapshot or degraded empty-shell state is available
+- managed app surfaces should dismiss full-page splash once launch context and initial surface structure are ready
+- live media connection state belongs to tiles and section-level status after first paint
+
 ## Discovery and Directory
 Zones remain the discovery scope:
 - zone keys are operator/user-shared

--- a/app.js
+++ b/app.js
@@ -1,4 +1,10 @@
 import { IdentityClient } from './identity/client.js';
+import {
+  SHELL_BOOT_FALLBACK_TIMEOUT_MS,
+  SHELL_BOOT_RUNTIME_ATTACH_TIMEOUT_MS,
+  describeShellResourceNameState,
+  shellBootCanDismiss,
+} from './app/loading.js';
 import { createManagedApplianceModel } from './app/managed-appliances.js';
 
 const panePathEl = document.getElementById('panePath');
@@ -204,6 +210,8 @@ let lastManagedServiceIssue = null;
 let lastRuntimeShellStatusKey = '';
 let bootSplashDismissed = false;
 const resolvedResourceNames = new Map();
+const shellBootDebugEnabled = new URLSearchParams(window.location.search || '').get('debug') === '1';
+let shellBootFallbackTimer = null;
 const managedAppliances = createManagedApplianceModel({
   applyHostedSnapshot: (record) => applyGatewayHostedSnapshot(record),
   getSwarmSeen: (pk) => (swarm ? swarm.getSwarmSeen(pk) : 0),
@@ -270,6 +278,68 @@ function dismissBootSplash() {
   }, 220);
 }
 
+function markShellBoot(stage) {
+  const label = String(stage || '').trim();
+  if (!label) return;
+  try {
+    performance.mark(`constitute:${label}`);
+  } catch {}
+  if (shellBootDebugEnabled) {
+    try {
+      console.debug('[boot]', label, Math.round(performance.now()));
+    } catch {
+      console.debug('[boot]', label);
+    }
+  }
+}
+
+function clearShellBootFallbackTimer() {
+  if (!shellBootFallbackTimer) return;
+  clearTimeout(shellBootFallbackTimer);
+  shellBootFallbackTimer = null;
+}
+
+function tryDismissShellBootSplash(reason = '') {
+  if (bootSplashDismissed) return true;
+  const canDismiss = shellBootCanDismiss({
+    runtimeAttached,
+    fallbackExpired: !shellBootFallbackTimer,
+  });
+  if (!canDismiss) return false;
+  markShellBoot(reason || (runtimeAttached ? 'shell.first-paint.snapshot' : 'shell.first-paint.fallback'));
+  dismissBootSplash();
+  return true;
+}
+
+function scheduleShellBootFallback() {
+  clearShellBootFallbackTimer();
+  shellBootFallbackTimer = setTimeout(() => {
+    shellBootFallbackTimer = null;
+    renderConnectionModel('boot-fallback');
+    renderHomeApps();
+    if (lastIdentity) renderApplianceList(lastIdentity?.devices || [], lastSwarmDevices || []);
+    tryDismissShellBootSplash('shell.first-paint.fallback');
+  }, SHELL_BOOT_FALLBACK_TIMEOUT_MS);
+}
+
+function bootFromRuntimeSnapshot() {
+  scheduleShellBootFallback();
+  runtimeBridge = startPlatformRuntimeBridge();
+  if (!runtimeBridge) {
+    markShellBoot('shell.runtime-attach.unavailable');
+    return null;
+  }
+  runtimeBridge.whenReady(SHELL_BOOT_RUNTIME_ATTACH_TIMEOUT_MS)
+    .then(() => {
+      markShellBoot('shell.runtime-attached');
+    })
+    .catch((err) => {
+      console.warn('[runtime] runtime attach bootstrap failed', err);
+      markShellBoot('shell.runtime-attach.timeout');
+    });
+  return runtimeBridge;
+}
+
 function bootSplashCopy(reason = '') {
   if (daemonState === 'online') {
     return {
@@ -312,17 +382,12 @@ function conciseConnectionReason(summary) {
 function describeShellResourceName(pk, fallback = '') {
   const key = String(pk || '').trim();
   const raw = String(fallback || shortPk(key)).trim() || '—';
-  if (!key) {
-    return { text: raw, loading: false, raw: false };
-  }
-  const resolved = resolvedResourceNames.get(key);
-  if (resolved) {
-    return { text: resolved, loading: false, raw: false };
-  }
-  if (!bootRefreshSettled || !runtimeAttached) {
-    return { text: 'Loading name…', loading: true, raw: false };
-  }
-  return { text: raw, loading: false, raw: true };
+  return describeShellResourceNameState({
+    pk: key,
+    fallback: raw,
+    resolvedLabel: resolvedResourceNames.get(key) || '',
+    runtimeAttached,
+  });
 }
 
 function rememberResolvedResourceName(pk, label) {
@@ -339,6 +404,7 @@ function absorbRuntimeSnapshot(snapshot) {
   for (const [pk, label] of Object.entries(names)) {
     rememberResolvedResourceName(pk, label);
   }
+  markShellBoot('shell.runtime-snapshot');
 }
 
 function updateBootSplash(reason = '') {
@@ -1498,6 +1564,8 @@ function startPlatformRuntimeBridge() {
       renderConnectionModel();
       renderHomeApps();
       if (lastIdentity) renderApplianceList(lastIdentity?.devices || [], lastSwarmDevices || []);
+      clearShellBootFallbackTimer();
+      tryDismissShellBootSplash('shell.first-paint.snapshot');
       return;
     }
     if (msg.type === 'runtime.snapshot') {
@@ -1513,6 +1581,8 @@ function startPlatformRuntimeBridge() {
       renderConnectionModel();
       renderHomeApps();
       if (lastIdentity) renderApplianceList(lastIdentity?.devices || [], lastSwarmDevices || []);
+      clearShellBootFallbackTimer();
+      tryDismissShellBootSplash('shell.first-paint.snapshot');
       return;
     }
     if (msg.type === 'runtime.broker.request') {
@@ -3605,6 +3675,18 @@ async function hydrateAppCatalog() {
   }
 }
 
+function hydrateAppCatalogInBackground() {
+  return (async () => {
+    try {
+      await hydrateAppCatalog();
+      markShellBoot('shell.app-catalog.hydrated');
+      renderHomeApps();
+    } catch (err) {
+      console.error('hydrateAppCatalog failed', err);
+    }
+  })();
+}
+
 function clear(el) {
   if (!el) return;
   while (el.firstChild) el.removeChild(el.firstChild);
@@ -4065,9 +4147,45 @@ function ensureOnboardingState(ident) {
 }
 
 async function refreshAll() {
+  const core = await refreshCoreState();
+  await refreshExtendedState(core);
+  return { st: core.st, ident: core.ident };
+}
+
+function applyCoreRefreshState({ st, ident, myLabel }) {
+  lastDeviceState = st;
+  lastIdentity = ident;
+  if (preparedGatewayInstall && preparedGatewayInstall.identityLabel !== String(ident?.label || '').trim()) {
+    preparedGatewayInstall = null;
+  }
+  setDaemonState('online', 'rpc ok');
+  deviceDid.textContent = st.did || '';
+  deviceDidSummary.textContent = String(myLabel?.label || 'This device').trim() || 'This device';
+  deviceSecuritySummary.textContent = st.didMethod === 'webauthn' ? 'Protected' : 'Basic';
+  identityLinkedSummary.textContent = ident?.linked ? currentIdentityHandle() : 'Not signed in';
+  updateIdentityChrome(ident);
+  deviceLabel.value = myLabel?.label || '';
+  updateGatewayInstallHint();
+  renderDeviceList(ident?.devices || []);
+  renderApplianceList(ident?.devices || [], lastSwarmDevices);
+  renderHomeApps();
+  ensureOnboardingState(ident);
+  renderConnectionModel('refresh');
+}
+
+async function refreshCoreState() {
   // SEQUENTIAL (not Promise.all) to avoid SW starvation/timeouts.
   const st = await client.call('device.getState', {}, { timeoutMs: 20000 });
   const ident = await client.call('identity.get', {}, { timeoutMs: 20000 });
+  const myLabel = await client.call('device.getLabel', {}, { timeoutMs: 20000 });
+  applyCoreRefreshState({ st, ident, myLabel });
+  markShellBoot('shell.core-refresh.complete');
+  return { st, ident, myLabel };
+}
+
+async function refreshExtendedState(core = null) {
+  const st = core?.st || lastDeviceState || await client.call('device.getState', {}, { timeoutMs: 20000 });
+  const ident = core?.ident || lastIdentity || await client.call('identity.get', {}, { timeoutMs: 20000 });
   const reqs = await client.call('pairing.list', {}, { timeoutMs: 20000 });
   const blocked = await client.call('blocked.list', {}, { timeoutMs: 20000 });
   const directory = await client.call('directory.list', {}, { timeoutMs: 20000 });
@@ -4075,20 +4193,13 @@ async function refreshAll() {
   const swarmDevices = await client.call('swarm.device.list', {}, { timeoutMs: 20000 }).catch(() => []);
   const swarmIdentities = await client.call('swarm.identity.list', {}, { timeoutMs: 20000 }).catch(() => []);
   const notifs = await client.call('notifications.list', {}, { timeoutMs: 20000 });
-  const myLabel = await client.call('device.getLabel', {}, { timeoutMs: 20000 });
 
-  lastDeviceState = st;
-  lastIdentity = ident;
-  if (preparedGatewayInstall && preparedGatewayInstall.identityLabel !== String(ident?.label || '').trim()) {
-    preparedGatewayInstall = null;
-  }
   lastDirectory = directory || [];
   lastZones = zones || [];
   lastSwarmDevices = swarmDevices || [];
   await refreshGatewayGrantViews(ident?.devices || [], lastSwarmDevices).catch(() => {});
   relayBridge?.updateTargets(desiredRelayUrls(ident?.devices || [], lastSwarmDevices), 'refresh');
 
-  // If we only have a key, try to resolve the human name via peers.
   for (const z of (lastZones || [])) {
     const n = String(z?.name || '').trim();
     if (!n || n === 'Joined' || n.startsWith('Zone ')) {
@@ -4097,28 +4208,14 @@ async function refreshAll() {
     }
   }
 
-  setDaemonState('online', 'rpc ok');
-
-  deviceDid.textContent = st.did || '';
-  deviceDidSummary.textContent = String(myLabel?.label || 'This device').trim() || 'This device';
-  deviceSecuritySummary.textContent = st.didMethod === 'webauthn' ? 'Protected' : 'Basic';
-  identityLinkedSummary.textContent = ident?.linked ? currentIdentityHandle() : 'Not signed in';
-  updateIdentityChrome(ident);
-
-  deviceLabel.value = myLabel?.label || '';
-  updateGatewayInstallHint();
-
-  renderDeviceList(ident?.devices || []);
   renderBlockedList(blocked || []);
   renderZones(lastZones);
   renderPeers(lastDirectory);
   updateZoneCommandUi();
-  renderApplianceList(ident?.devices || [], lastSwarmDevices);
   pushRuntimeManagedApplianceSourceSnapshot(ident?.devices || [], lastSwarmDevices);
-  renderHomeApps();
   renderPairRequests(reqs || [], ident?.devices || []);
   renderNotifications(notifs || []);
-  ensureOnboardingState(ident);
+
   const applianceRecords = currentManagedApplianceRecords(ident?.devices || [], lastSwarmDevices);
   const ownedGatewayPksNeedingRefresh = applianceRecords
     .filter((rec) => isGatewayRecord(rec))
@@ -4145,7 +4242,8 @@ async function refreshAll() {
     setSwarmState('disabled');
   }
 
-  renderConnectionModel('refresh');
+  renderConnectionModel('extended-refresh');
+  markShellBoot('shell.extended-refresh.complete');
   return { st, ident };
 }
 
@@ -4962,6 +5060,7 @@ function startSharedRelayPipe(client, initialRelayUrls) {
   // Keep activity panes hidden until identity/device gating completes.
   panePathEl.textContent = '';
   setBootSplash();
+  markShellBoot('shell.boot.start');
 
   client = new IdentityClient({
     onEvent: (evt) => {
@@ -4993,14 +5092,7 @@ function startSharedRelayPipe(client, initialRelayUrls) {
     }
   });
 
-  await client.ready().catch((e) => console.error(e));
-  clientReady = client.isServiceWorkerAvailable();
-  if (clientReady) {
-    relayBridge = startSharedRelayPipe(client, desiredRelayUrls([], []));
-    runtimeBridge = startPlatformRuntimeBridge();
-  } else {
-    setDaemonState('offline', 'sw unavailable');
-  }
+  bootFromRuntimeSnapshot();
 
   swarm = new SwarmTransport({ client, onState: (s) => setSwarmState(s) });
   swarm.loadSuccess();
@@ -5014,14 +5106,28 @@ function startSharedRelayPipe(client, initialRelayUrls) {
 
   loadGatewayExtraZones();
   wireUi();
-  await hydrateAppCatalog();
   renderConnectionModel('init');
+  void hydrateAppCatalogInBackground();
 
   // Default radio selection: webauthn if supported
   setSecurityChoice('webauthn');
 
   try {
-    await runRefreshAll();
+    await client.ready();
+    clientReady = client.isServiceWorkerAvailable();
+    markShellBoot('shell.client-ready');
+    if (clientReady) {
+      relayBridge = startSharedRelayPipe(client, desiredRelayUrls([], []));
+    } else {
+      setDaemonState('offline', 'sw unavailable');
+    }
+
+    const core = await refreshCoreState();
+    bootRefreshSettled = true;
+    relayBridge?.flushBootState?.();
+    clearShellBootFallbackTimer();
+    tryDismissShellBootSplash('shell.first-paint.core');
+
     const linked = await ensureOnboardingFlow();
     if (linked) {
       setSettingsTab('devices');
@@ -5029,16 +5135,19 @@ function startSharedRelayPipe(client, initialRelayUrls) {
     } else {
       await applyUrlParams();
     }
+
+    void refreshExtendedState(core).catch((err) => {
+      console.error('refreshExtendedState failed', err);
+      renderConnectionModel('extended-refresh-failed');
+    });
   } catch (e) {
-    console.error('refreshAll failed', e);
+    console.error('shell boot failed', e);
     setDaemonState('offline', 'rpc failed');
     showActivity('onboarding');
     setOnboardStep(1);
-  } finally {
     bootRefreshSettled = true;
-    relayBridge?.flushBootState?.();
-    scheduleRefreshAll(0);
-    dismissBootSplash();
+    clearShellBootFallbackTimer();
+    tryDismissShellBootSplash('shell.first-paint.error');
   }
 
   // Health check: if SW drops, fall back to onboarding.

--- a/app/loading.js
+++ b/app/loading.js
@@ -1,0 +1,33 @@
+export const SHELL_BOOT_RUNTIME_ATTACH_TIMEOUT_MS = 900;
+export const SHELL_BOOT_FALLBACK_TIMEOUT_MS = 1_600;
+export const SW_READY_GRACE_MS = 400;
+export const SW_CONTROLLER_GRACE_MS = 800;
+
+export function shellBootCanDismiss({ runtimeAttached = false, fallbackExpired = false } = {}) {
+  return runtimeAttached || fallbackExpired;
+}
+
+export function describeShellResourceNameState({
+  pk = "",
+  fallback = "",
+  resolvedLabel = "",
+  runtimeAttached = false,
+} = {}) {
+  const key = String(pk || "").trim();
+  const raw = String(fallback || "").trim() || "—";
+  const resolved = String(resolvedLabel || "").trim();
+  if (!key) {
+    return { text: raw, loading: false, raw: false };
+  }
+  if (resolved) {
+    return { text: resolved, loading: false, raw: false };
+  }
+  if (runtimeAttached) {
+    return { text: "Loading name…", loading: true, raw: false };
+  }
+  return { text: raw, loading: false, raw: true };
+}
+
+export function bootControllerMode({ controllerPresent = false } = {}) {
+  return controllerPresent ? "controller" : "direct-fallback";
+}

--- a/app/loading.test.js
+++ b/app/loading.test.js
@@ -1,0 +1,66 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  SHELL_BOOT_FALLBACK_TIMEOUT_MS,
+  SHELL_BOOT_RUNTIME_ATTACH_TIMEOUT_MS,
+  SW_CONTROLLER_GRACE_MS,
+  SW_READY_GRACE_MS,
+  bootControllerMode,
+  describeShellResourceNameState,
+  shellBootCanDismiss,
+} from "./loading.js";
+
+test("shell boot dismisses immediately once runtime snapshot is attached", () => {
+  assert.equal(shellBootCanDismiss({ runtimeAttached: true, fallbackExpired: false }), true);
+});
+
+test("shell boot dismisses after fallback timeout even without runtime snapshot", () => {
+  assert.equal(shellBootCanDismiss({ runtimeAttached: false, fallbackExpired: true }), true);
+});
+
+test("resource names render from shared-runtime snapshot immediately", () => {
+  assert.deepEqual(
+    describeShellResourceNameState({
+      pk: "pk-1",
+      fallback: "pk-1",
+      resolvedLabel: "Front Door",
+      runtimeAttached: false,
+    }),
+    { text: "Front Door", loading: false, raw: false },
+  );
+});
+
+test("resource names stay in loading state when runtime is attached but label is unresolved", () => {
+  assert.deepEqual(
+    describeShellResourceNameState({
+      pk: "pk-1",
+      fallback: "pk-1",
+      resolvedLabel: "",
+      runtimeAttached: true,
+    }),
+    { text: "Loading name…", loading: true, raw: false },
+  );
+});
+
+test("resource names fall back to raw identifier before runtime snapshot arrives", () => {
+  assert.deepEqual(
+    describeShellResourceNameState({
+      pk: "pk-1",
+      fallback: "pk-1",
+      resolvedLabel: "",
+      runtimeAttached: false,
+    }),
+    { text: "pk-1", loading: false, raw: true },
+  );
+});
+
+test("no-controller boot path always prefers direct fallback over reload", () => {
+  assert.equal(bootControllerMode({ controllerPresent: false }), "direct-fallback");
+});
+
+test("startup grace windows stay short", () => {
+  assert.ok(SW_READY_GRACE_MS < 1_000);
+  assert.ok(SW_CONTROLLER_GRACE_MS < 2_000);
+  assert.ok(SHELL_BOOT_RUNTIME_ATTACH_TIMEOUT_MS < SHELL_BOOT_FALLBACK_TIMEOUT_MS);
+});

--- a/identity/client.js
+++ b/identity/client.js
@@ -5,6 +5,12 @@
 // The Service Worker is single-threaded and uses IndexedDB; sending many
 // concurrent RPCs can cause contention and apparent hangs/timeouts.
 
+import {
+  SW_CONTROLLER_GRACE_MS,
+  SW_READY_GRACE_MS,
+  bootControllerMode,
+} from "../app/loading.js";
+
 const SERVICE_WORKER_BUILD_ID = "2026-04-06-runtime-stage3";
 
 function currentServiceWorkerUrl() {
@@ -87,25 +93,25 @@ export class IdentityClient {
       console.log("[client] waiting for SW ready");
       await Promise.race([
         navigator.serviceWorker.ready,
-        new Promise((resolve) => setTimeout(resolve, 3000)),
+        new Promise((resolve) => setTimeout(resolve, SW_READY_GRACE_MS)),
       ]);
 
-      // First load after registration may need a controller; wait a bit.
+      // Give the controller a short grace window, then continue on the
+      // direct-port path instead of forcing a reload.
       console.log("[client] waiting for controller");
       let controllerOk = false;
       try {
-        await this._waitForController(9000);
+        await this._waitForController(SW_CONTROLLER_GRACE_MS);
         controllerOk = true;
       } catch (e) {
-        // On first registration, controller may not attach until reload.
-        const k = "sw:reloaded";
-        if (!sessionStorage.getItem(k)) {
-          sessionStorage.setItem(k, "1");
-          console.warn("[client] no controller; reloading to attach SW");
-          location.reload();
-          return reg;
+        const mode = bootControllerMode({
+          controllerPresent: Boolean(navigator.serviceWorker.controller),
+        });
+        if (mode === "controller") {
+          controllerOk = true;
+        } else {
+          console.warn("[client] controller unavailable; continuing with direct port fallback");
         }
-        console.warn("[client] controller unavailable; continuing with direct port fallback");
       }
       if (controllerOk) console.log("[client] controller ready");
       return reg;


### PR DESCRIPTION
## Summary
- boot the shell from the shared runtime snapshot instead of blocking on full hydration
- shorten service-worker/controller grace and prefer direct fallback with no boot-time reload
- move core and extended refresh work off the initial first-paint path

## Validation
- `npm test`
- `npm run build`
- Firefox localhost shell smoke confirmed the blocking boot path is gone and the splash clears on first usable paint

Closes #18