### PR TITLE
Add runtime projection materialization

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -81,7 +81,7 @@ Browser UI
 - `identity/client.js`
   - window-to-Service Worker RPC bridge
 - `runtime.worker.js`
-  - same-origin shared runtime for managed service access context, cross-surface status, and gateway request brokering
+  - same-origin shared runtime for managed service access context, retained projections, cross-surface status, and gateway request brokering
 - `relay.worker.js`
   - persistent WebSocket relay bridge for relay pool transport only
 
@@ -110,6 +110,7 @@ Service Worker
 - WebRTC is the preferred browser-safe transport direction for managed live media and direct paths
 - shell service access/bootstrap must stay separate from media transport
 - retained runtime projection is first truth for display/session hints until contradicted
+- retained runtime projections are first truth for generic consumable service data, including logging event and health projections
 - privileged service admission still requires valid cryptographic authorization
 - service access uses `constitute-protocol` CAAC primitives for explicit capability state bound to identity, device, gateway, service, scope, expiry, and replay protection
 
@@ -140,6 +141,26 @@ Background hydration owns:
 - managed app surfaces should dismiss full-page splash once service access context and initial surface structure are ready
 - live media connection state belongs to tiles and section-level status after first paint
 - onboarding progress should remain stable while background hydration continues; refresh loops must not snap the user back to step one unless the device truly lost its local authority
+
+## Runtime Projection Contract
+
+The shared runtime owns retained projection storage for browser-safe, capability-scoped data that can be consumed by multiple first-party app surfaces.
+
+Current projection rules:
+- projection channels are named and typed by `constitute-protocol`
+- projection payloads stay domain-generic where the domain supports it; logging uses generic log event envelopes instead of per-service UI schemas
+- browser apps render retained/materialized projections first and observe runtime updates
+- account/runtime syncs missing, stale, or incomplete projections through service-owned CAAC exchange, with Gateway only routing and attesting
+- broker/control exists for service access and projection sync/repair; it is not the primary product data interface
+- runtime stores materialized projections generically by service identity, channel, and policy id; it does not own Logging, NVR, or Storage domain semantics
+- runtime owns browser-side IndexedDB materialization, coverage tracking, and observer updates
+- service-owned projection responses are authoritative for their policy; runtime replaces that materialized event set rather than unioning stale rows forever
+- semantically unchanged projections must not trigger persistence, snapshots, or observer updates
+- UI surfaces do not coordinate chunks, cursors, scroll paging, or service query windows
+
+Initial projection channels:
+- `logging.events`
+- `logging.health`
 
 ## Discovery and Directory
 Zones remain the discovery scope:
@@ -184,6 +205,7 @@ Current convergence work is focused on:
 - gateway-management extraction into `constitute-gateway-ui`
 - managed NVR service access into `constitute-nvr-ui`
 - shared non-UI protocol/security/control primitives in `constitute-protocol`
+- runtime-propagated logging projections for `constitute-logging-ui`
 - WebRTC live preview as the managed browser media direction
 
 ## Design Principles

--- a/app.js
+++ b/app.js
@@ -5,7 +5,7 @@ import {
   renderFirstPartyShell,
   setConnectionStateText,
 } from "constitute-ui";
-import { BROKER, SERVICE_ACCESS_EVENTS } from "constitute-protocol";
+import { BROKER, PROJECTION, SERVICE_ACCESS_EVENTS, SERVICE_EXCHANGE, makeServiceExchangeFrame } from "constitute-protocol";
 import { IdentityClient } from './identity/client.js';
 import {
   SHELL_BOOT_FALLBACK_TIMEOUT_MS,
@@ -291,12 +291,14 @@ const SWARM_ICE_SERVERS = [
 ];
 
 const SHELL_BUILD_ID = '2026-04-06-runtime-stage3';
-const PLATFORM_RUNTIME_VERSION = Object.freeze({ major: 2, minor: 9 });
+const PLATFORM_RUNTIME_VERSION = Object.freeze({ major: 2, minor: 12 });
 const PLATFORM_RUNTIME_BUILD_ID = `runtime-${PLATFORM_RUNTIME_VERSION.major}.${PLATFORM_RUNTIME_VERSION.minor}`;
 const RUNTIME_ATTACH_TIMEOUT_MS = 15_000;
 const RUNTIME_WRITE_TIMEOUT_MS = 12_000;
 const MANAGED_SERVICE_ACCESS_REQUEST_TIMEOUT_MS = 90_000;
 const GATEWAY_SIGNAL_REQUEST_TIMEOUT_MS = 135_000;
+const PROJECTION_SERVICE_ACCESS_TIMEOUT_MS = 25_000;
+const PROJECTION_SIGNAL_REQUEST_TIMEOUT_MS = 30_000;
 const BROKER_READY_TIMEOUT_MS = 45_000;
 const BROKER_RELAY_READY_TIMEOUT_MS = 30_000;
 const BROKER_READY_POLL_MS = 250;
@@ -328,6 +330,7 @@ let swarmBootRequested = false;
 const GATEWAY_EXTRA_ZONES_KEY = 'constitute.gateway.extraZones';
 const MANAGED_APP_SURFACES = Object.freeze({
   nvr: 'constitute-nvr-ui',
+  logging: 'constitute-logging-ui',
 });
 const MANAGED_SERVICE_ACCESS_TTL_MS = 2 * 60 * 1000;
 const GATEWAY_INVENTORY_REFRESH_TTL_MS = 15_000;
@@ -350,6 +353,7 @@ let runtimeStatusSnapshot = {
   services: {},
   managedAppliances: { owned: [], granted: [], discoverable: [] },
   resourceNames: {},
+  projections: {},
   managedServiceIssue: null,
   serviceAccessContextCount: 0,
 };
@@ -408,6 +412,18 @@ function runtimeManagedApplianceRecords() {
 
 function identityOwnedDevicePks() {
   return Array.from(ownedPkSet(lastIdentity?.devices || []));
+}
+
+function runtimeOwnedDevicePks() {
+  return runtimeManagedApplianceBucket('owned')
+    .flatMap((record) => [
+      record?.devicePk,
+      record?.pk,
+      record?.hostGatewayPk,
+      record?.host_gateway_pk,
+    ])
+    .map((value) => String(value || '').trim())
+    .filter(Boolean);
 }
 
 function currentManagedApplianceRecords(identityDevices = lastIdentity?.devices || [], swarmDevices = lastSwarmDevices || []) {
@@ -1625,6 +1641,23 @@ function createPendingRequest(map, requestId, label, timeoutMs = 20_000) {
   });
 }
 
+function observePendingRequest(promise) {
+  const state = {
+    error: null,
+    promise: Promise.resolve(promise).catch((error) => {
+      state.error = error;
+      return undefined;
+    }),
+  };
+  return state;
+}
+
+async function awaitObservedPendingRequest(state) {
+  const result = await state.promise;
+  if (state.error) throw state.error;
+  return result;
+}
+
 async function waitForBrokerCondition(predicate, timeoutMs, label) {
   const deadline = Date.now() + Math.max(0, Number(timeoutMs) || 0);
   while (true) {
@@ -1810,6 +1843,17 @@ function startPlatformRuntimeBridge() {
     }
   };
 
+  const runtimeWriteWarnings = new Map();
+  function warnRuntimeWriteFailure(key, err) {
+    const now = Date.now();
+    const prior = runtimeWriteWarnings.get(key) || { count: 0, lastAt: 0 };
+    const next = { count: prior.count + 1, lastAt: now };
+    runtimeWriteWarnings.set(key, next);
+    if (now - prior.lastAt < 30_000) return;
+    const suffix = next.count > 1 ? ` (${next.count} recent failures)` : '';
+    console.warn(`[runtime] ${key} failed${suffix}`, err);
+  }
+
   function runtimeCall(type, payload = {}, timeoutMs = 20_000) {
     const requestId = `${clientId}-${type}-${bridge.requestId++}`;
     return new Promise((resolve, reject) => {
@@ -1830,13 +1874,13 @@ function startPlatformRuntimeBridge() {
   bridge.pushStatus = async (status) => {
     if (!(await bridge.whenReadyQuietly())) return;
     await runtimeCall('runtime.status.put', { role: 'shell', status }, RUNTIME_WRITE_TIMEOUT_MS).catch((err) => {
-      console.warn('[runtime] runtime.status.put failed', err);
+      warnRuntimeWriteFailure('runtime.status.put', err);
     });
   };
   bridge.putManagedApplianceSourceSnapshot = async (sourceSnapshot) => {
     if (!(await bridge.whenReadyQuietly())) return;
     await runtimeCall('managedAppliances.sourceSnapshot.put', { sourceSnapshot }, RUNTIME_WRITE_TIMEOUT_MS).catch((err) => {
-      console.warn('[runtime] managedAppliances.sourceSnapshot.put failed', err);
+      warnRuntimeWriteFailure('managedAppliances.sourceSnapshot.put', err);
     });
   };
 
@@ -1880,13 +1924,14 @@ function startPlatformRuntimeBridge() {
     if (msg.type === 'runtime.broker.request') {
       handleRuntimeBrokerRequest(msg).catch((err) => {
         const kind = String(msg?.kind || '').trim();
-        const responseType = kind === BROKER.SERVICE_ACCESS_REQUEST
-          ? BROKER.SERVICE_ACCESS_RESPONSE
-          : (kind === 'gateway.grant.request'
-            ? 'gateway.grant.response'
-            : (kind === 'gateway.service.install.request'
-              ? 'gateway.service.install.response'
-              : (kind === 'gateway.zones.sync.request' ? 'gateway.zones.sync.response' : BROKER.SERVICE_SIGNAL_RESPONSE)));
+        const responseTypes = {
+          [BROKER.SERVICE_ACCESS_REQUEST]: BROKER.SERVICE_ACCESS_RESPONSE,
+          [BROKER.SERVICE_PROJECTION_REQUEST]: BROKER.SERVICE_PROJECTION_RESPONSE,
+          'gateway.grant.request': 'gateway.grant.response',
+          'gateway.service.install.request': 'gateway.service.install.response',
+          'gateway.zones.sync.request': 'gateway.zones.sync.response',
+        };
+        const responseType = responseTypes[kind] || BROKER.SERVICE_SIGNAL_RESPONSE;
         port.postMessage({
           type: responseType,
           clientId,
@@ -1944,6 +1989,17 @@ async function handleRuntimeBrokerRequest(message) {
     const result = await requestGatewayServiceAccess(payload.record || payload, payload.options || {});
     runtimeBridge.port.postMessage({
       type: BROKER.SERVICE_ACCESS_RESPONSE,
+      clientId: runtimeBridge.clientId,
+      requestId,
+      ok: true,
+      result,
+    });
+    return;
+  }
+  if (kind === BROKER.SERVICE_PROJECTION_REQUEST) {
+    const result = await requestServiceProjection(payload);
+    runtimeBridge.port.postMessage({
+      type: BROKER.SERVICE_PROJECTION_RESPONSE,
       clientId: runtimeBridge.clientId,
       requestId,
       ok: true,
@@ -2475,13 +2531,15 @@ async function requestGatewayServiceAccess(record, opts = {}) {
   const servicePk = managedServicePkForRecord(record);
   const service = String(opts?.service || record?.service || 'nvr').trim() || 'nvr';
   const capability = String(opts?.capability || `${service}.view`).trim() || `${service}.view`;
+  const timeoutMs = Number(opts?.timeoutMs || 0) || MANAGED_SERVICE_ACCESS_REQUEST_TIMEOUT_MS;
   if (!gatewayPk) throw new Error('host gateway is not known for this service yet');
   if (!servicePk) throw new Error('service public key is missing');
   if (!String(lastIdentity?.id || '').trim()) throw new Error('link an identity before opening managed services');
   if (!String(lastDeviceState?.pk || '').trim()) throw new Error('device key is not ready yet');
   const requestServiceAccessOnce = async () => {
     const requestId = randomOpaqueId('gw-service-access');
-    const pending = createPendingRequest(pendingServiceAccesses, requestId, 'service access', MANAGED_SERVICE_ACCESS_REQUEST_TIMEOUT_MS);
+    const pending = createPendingRequest(pendingServiceAccesses, requestId, 'service access', timeoutMs);
+    const observedPending = observePendingRequest(pending);
     try {
       await client.call('gateway.serviceAccess.request', {
         requestId,
@@ -2494,12 +2552,12 @@ async function requestGatewayServiceAccess(record, opts = {}) {
           shell: 'constitute',
           surface: managedAppSurfaceRepoForService(service),
         },
-      }, { timeoutMs: MANAGED_SERVICE_ACCESS_REQUEST_TIMEOUT_MS });
+      }, { timeoutMs });
     } catch (err) {
       settlePending(pendingServiceAccesses, requestId, err);
       throw err;
     }
-    return await pending;
+    return await awaitObservedPendingRequest(observedPending);
   };
   for (let attempt = 1; attempt <= 3; attempt += 1) {
     try {
@@ -2522,9 +2580,11 @@ async function requestGatewaySignal(req) {
   const requestId = String(req?.requestId || '').trim() || randomOpaqueId('gw-signal');
   const signalType = String(req?.signalType || '').trim().toLowerCase();
   if (!signalType) throw new Error('missing signal type');
-  const pendingTimeoutMs = signalType === 'offer' ? 30_000 : GATEWAY_SIGNAL_REQUEST_TIMEOUT_MS;
-  const callTimeoutMs = signalType === 'offer' ? 30_000 : GATEWAY_SIGNAL_REQUEST_TIMEOUT_MS;
+  const requestedTimeoutMs = Number(req?.timeoutMs || 0);
+  const pendingTimeoutMs = requestedTimeoutMs || (signalType === 'offer' ? 30_000 : GATEWAY_SIGNAL_REQUEST_TIMEOUT_MS);
+  const callTimeoutMs = requestedTimeoutMs || (signalType === 'offer' ? 30_000 : GATEWAY_SIGNAL_REQUEST_TIMEOUT_MS);
   const pending = createPendingRequest(pendingGatewaySignals, requestId, `gateway ${signalType}`, pendingTimeoutMs);
+  const observedPending = observePendingRequest(pending);
   try {
     await client.call(BROKER.SERVICE_SIGNAL_REQUEST, {
       requestId,
@@ -2539,7 +2599,163 @@ async function requestGatewaySignal(req) {
     settlePending(pendingGatewaySignals, requestId, err);
     throw err;
   }
-  return await pending;
+  return await awaitObservedPendingRequest(observedPending);
+}
+
+function findManagedServiceRecordForProjection(service = 'logging') {
+  const targetService = String(service || 'logging').trim().toLowerCase() || 'logging';
+  const records = currentManagedApplianceRecords(lastIdentity?.devices || [], lastSwarmDevices || []);
+  const owned = new Set([
+    ...ownedPkSet(lastIdentity?.devices || []),
+    ...runtimeOwnedDevicePks(),
+  ]);
+  const hosted = records.find((rec) => {
+    if (String(rec?.service || '').trim().toLowerCase() !== targetService) return false;
+    const gatewayPk = managedGatewayPkForRecord(rec);
+    const servicePk = managedServicePkForRecord(rec);
+    return Boolean(servicePk) && (owned.has(gatewayPk) || rec?.grantedRecord === true || rec?.sharedProjection === true);
+  }) || records.find((rec) => {
+    if (String(rec?.service || '').trim().toLowerCase() !== targetService) return false;
+    return Boolean(managedGatewayPkForRecord(rec)) && Boolean(managedServicePkForRecord(rec));
+  });
+  if (hosted) return hosted;
+  const projectedService = retainedProjectionServiceRecord(targetService);
+  const recordWithoutServicePk = records.find((rec) => {
+    if (String(rec?.service || '').trim().toLowerCase() !== targetService) return false;
+    return Boolean(managedGatewayPkForRecord(rec));
+  });
+  if (projectedService?.servicePk && recordWithoutServicePk) {
+    return {
+      ...recordWithoutServicePk,
+      servicePk: projectedService.servicePk,
+      hostGatewayPk: managedGatewayPkForRecord(recordWithoutServicePk) || projectedService.hostGatewayPk,
+      service: targetService,
+    };
+  }
+  const gateway = freshestOwnedGatewayRecord();
+  const gatewayPk = managedGatewayPkForRecord(gateway);
+  if (!gatewayPk && !projectedService?.hostGatewayPk) return null;
+  if (!projectedService?.servicePk) return null;
+  return {
+    role: targetService,
+    service: targetService,
+    hostGatewayPk: gatewayPk || projectedService.hostGatewayPk,
+    servicePk: projectedService.servicePk,
+    devicePk: `${targetService}:${gatewayPk || projectedService.hostGatewayPk}`,
+    deviceLabel: projectedService.label || targetService,
+    hostedSynthetic: true,
+  };
+}
+
+async function discoverManagedServiceRecordForProjection(service = 'logging') {
+  const targetService = String(service || 'logging').trim().toLowerCase() || 'logging';
+  let record = findManagedServiceRecordForProjection(targetService);
+  if (record) return record;
+
+  const records = currentManagedApplianceRecords(lastIdentity?.devices || [], lastSwarmDevices || []);
+  const owned = ownedPkSet(lastIdentity?.devices || []);
+  const gatewayPks = Array.from(new Set(
+    records
+      .filter((rec) => isGatewayRecord(rec))
+      .map((rec) => String(rec?.devicePk || rec?.pk || '').trim())
+      .filter((pk) => pk && owned.has(pk)),
+  ));
+  if (gatewayPks.length === 0) return null;
+
+  await Promise.all(gatewayPks.map((gatewayPk) => requestGatewayInventoryRefresh(gatewayPk, { force: true }).catch(() => false)));
+  const startedAt = Date.now();
+  while ((Date.now() - startedAt) < MANAGED_SERVICE_RESOLVE_TIMEOUT_MS) {
+    await refreshManagedApplianceProjection({ refreshGrantViews: false }).catch(() => []);
+    record = findManagedServiceRecordForProjection(targetService);
+    if (record) return record;
+    await new Promise((resolve) => window.setTimeout(resolve, MANAGED_SERVICE_RESOLVE_POLL_MS));
+  }
+  return findManagedServiceRecordForProjection(targetService);
+}
+
+function retainedProjectionServiceRecord(service = 'logging') {
+  const targetService = String(service || 'logging').trim().toLowerCase() || 'logging';
+  const projections = runtimeStatusSnapshot?.projections && typeof runtimeStatusSnapshot.projections === 'object'
+    ? runtimeStatusSnapshot.projections
+    : {};
+  for (const projection of Object.values(projections)) {
+    if (!projection || typeof projection !== 'object') continue;
+    if (String(projection?.service || '').trim().toLowerCase() !== targetService) continue;
+    const servicePk = String(projection?.servicePk || projection?.service_pk || '').trim();
+    if (!servicePk) continue;
+    return {
+      service: targetService,
+      servicePk,
+      hostGatewayPk: String(projection?.hostGatewayPk || projection?.host_gateway_pk || '').trim(),
+      label: String(projection?.display?.name || projection?.displayName || projection?.label || targetService).trim(),
+    };
+  }
+  return null;
+}
+
+async function requestServiceProjection(req) {
+  const channelId = String(req?.channelId || '').trim();
+  const service = String(req?.service || 'logging').trim().toLowerCase() || 'logging';
+  if (!channelId) {
+    throw new Error('missing projection channel');
+  }
+  const record = await discoverManagedServiceRecordForProjection(service);
+  if (!record) throw new Error(`${service} service is not available from this account runtime yet`);
+  const serviceLabel = String(record?.deviceLabel || record?.label || service).trim() || service;
+  const resolvedRecord = withManagedServiceAccessKeys(
+    await resolveManagedServiceForAccess(record, { serviceLabel, requireGatewayAuthority: false }),
+    record,
+  );
+  const gatewayPk = managedGatewayPkForRecord(resolvedRecord);
+  const servicePk = managedServicePkForRecord(resolvedRecord);
+  const capability = String(req?.capability || `${service}.view`).trim().toLowerCase();
+  const access = await requestGatewayServiceAccess(resolvedRecord, {
+    service,
+    capability,
+    timeoutMs: PROJECTION_SERVICE_ACCESS_TIMEOUT_MS,
+  });
+  const requestPayload = {
+    requestId: String(req?.requestId || '').trim(),
+    channelId,
+    service,
+    cursor: req?.cursor && typeof req.cursor === 'object'
+      ? req.cursor
+      : String(req?.cursor || '').trim(),
+    limit: Number(req?.limit || 0) || 100,
+    filters: req?.filters && typeof req.filters === 'object' ? req.filters : {},
+    policy: req?.policy && typeof req.policy === 'object' ? req.policy : {},
+  };
+  const frame = makeServiceExchangeFrame({
+    kind: SERVICE_EXCHANGE.KIND.PROJECTION_REQUEST,
+    issuerPk: String(lastDeviceState?.pk || lastIdentity?.devicePk || '').trim() || 'account-runtime',
+    recipientServicePk: String(access?.servicePk || servicePk || '').trim(),
+    hostGatewayPk: String(access?.gatewayPk || gatewayPk || '').trim(),
+    requestId: requestPayload.requestId,
+    traceId: String(req?.traceId || '').trim(),
+    sealedPayload: requestPayload,
+  });
+  const signal = await requestGatewaySignal({
+    gatewayPk: String(access?.gatewayPk || gatewayPk || '').trim(),
+    servicePk: String(access?.servicePk || servicePk || '').trim(),
+    service,
+    signalType: 'service_projection',
+    payload: {
+      frame,
+    },
+    serviceCapability: String(access?.serviceCapability || '').trim(),
+    timeoutMs: PROJECTION_SIGNAL_REQUEST_TIMEOUT_MS,
+  });
+  const payload = signal?.payload && typeof signal.payload === 'object' ? signal.payload : {};
+  const projection = payload.projection && typeof payload.projection === 'object' ? payload.projection : payload;
+  return {
+    projection: {
+      ...projection,
+      requestId: String(req?.requestId || projection?.requestId || signal?.requestId || '').trim(),
+      channelId: String(projection?.channelId || channelId).trim(),
+      service: String(projection?.service || service).trim(),
+      servicePk: String(projection?.servicePk || access?.servicePk || servicePk || '').trim(),
+    },
+  };
 }
 
 function managedServiceProjectionKey(record) {
@@ -2652,6 +2868,7 @@ async function requestGatewayGrantAction(record, opts = {}) {
   if (!action) throw new Error('missing grant action');
   const requestId = String(opts?.requestId || '').trim() || randomOpaqueId('gw-grant');
   const pending = createPendingRequest(pendingGatewayGrantRequests, requestId, `gateway ${action}`, 12_000);
+  const observedPending = observePendingRequest(pending);
   try {
     await client.call('gateway.grants.request', {
       requestId,
@@ -2668,7 +2885,7 @@ async function requestGatewayGrantAction(record, opts = {}) {
     settlePending(pendingGatewayGrantRequests, requestId, err);
     throw err;
   }
-  return await pending;
+  return await awaitObservedPendingRequest(observedPending);
 }
 
 async function refreshGatewayGrantViews(identityDevices, swarmDevices) {
@@ -2953,10 +3170,22 @@ function resolvedManagedServiceRecord(record, applianceRecords = []) {
   if (direct && isFreshManagedServiceRecord(direct)) return direct;
   if (gatewayPk) {
     const hosted = findGatewayHostedServiceRecord(gatewayPk, records, service);
-    if (hosted && isFreshManagedServiceRecord(hosted)) return hosted;
-    return hosted || direct;
+    if (hosted && isFreshManagedServiceRecord(hosted)) return withManagedServiceAccessKeys(hosted, record);
+    return hosted ? withManagedServiceAccessKeys(hosted, record) : direct;
   }
   return direct;
+}
+
+function withManagedServiceAccessKeys(record, fallbackRecord) {
+  const source = (record && typeof record === 'object') ? record : {};
+  const fallback = (fallbackRecord && typeof fallbackRecord === 'object') ? fallbackRecord : {};
+  const gatewayPk = managedGatewayPkForRecord(source) || managedGatewayPkForRecord(fallback);
+  const servicePk = managedServicePkForRecord(source) || managedServicePkForRecord(fallback);
+  return {
+    ...source,
+    hostGatewayPk: gatewayPk || String(source?.hostGatewayPk || source?.host_gateway_pk || '').trim(),
+    servicePk,
+  };
 }
 
 function isGatewayAuthoritativeManagedServiceRecord(record) {
@@ -2966,6 +3195,7 @@ function isGatewayAuthoritativeManagedServiceRecord(record) {
 async function resolveManagedServiceForAccess(record, opts = {}) {
   const gatewayPk = managedGatewayPkForRecord(record);
   const serviceLabel = String(opts?.serviceLabel || 'Security Cameras').trim() || 'Security Cameras';
+  const requireGatewayAuthority = opts?.requireGatewayAuthority !== false;
   if (!gatewayPk) {
     throw new Error(`${serviceLabel} is not attached to a gateway yet.`);
   }
@@ -2973,7 +3203,7 @@ async function resolveManagedServiceForAccess(record, opts = {}) {
     record,
     currentManagedApplianceRecords(lastIdentity?.devices || [], lastSwarmDevices || []),
   );
-  if (candidate && isFreshManagedServiceRecord(candidate) && isGatewayAuthoritativeManagedServiceRecord(candidate)) {
+  if (candidate && isFreshManagedServiceRecord(candidate) && (!requireGatewayAuthority || isGatewayAuthoritativeManagedServiceRecord(candidate))) {
     return candidate;
   }
 
@@ -2985,13 +3215,17 @@ async function resolveManagedServiceForAccess(record, opts = {}) {
       record,
       currentManagedApplianceRecords(lastIdentity?.devices || [], lastSwarmDevices || []),
     );
-    if (candidate && isFreshManagedServiceRecord(candidate) && isGatewayAuthoritativeManagedServiceRecord(candidate)) {
+    if (candidate && isFreshManagedServiceRecord(candidate) && (!requireGatewayAuthority || isGatewayAuthoritativeManagedServiceRecord(candidate))) {
       return candidate;
     }
     await new Promise((resolve) => window.setTimeout(resolve, MANAGED_SERVICE_RESOLVE_POLL_MS));
   }
 
   if (candidate && isGatewayAuthoritativeManagedServiceRecord(candidate)) {
+    return candidate;
+  }
+
+  if (candidate && !requireGatewayAuthority) {
     return candidate;
   }
 
@@ -3626,7 +3860,7 @@ async function refreshExtendedState(core = null) {
     .filter((rec) => isGatewayRecord(rec))
     .map((rec) => summarizeAppliance(rec, ownedPkSet(ident?.devices || []).has(String(rec?.devicePk || rec?.pk || '').trim())))
     .filter((info) => info.owned)
-    .filter((info) => !findGatewayHostedServiceRecord(info.pk, applianceRecords, 'nvr'))
+    .filter((info) => Object.keys(MANAGED_APP_SURFACES).some((service) => !findGatewayHostedServiceRecord(info.pk, applianceRecords, service)))
     .map((info) => info.pk);
   for (const gatewayPk of ownedGatewayPksNeedingRefresh) {
     requestGatewayInventoryRefresh(gatewayPk).catch(() => {});

--- a/app/managed-appliances.js
+++ b/app/managed-appliances.js
@@ -35,6 +35,16 @@ export function createManagedApplianceModel({
     return role === 'nvr' || service === 'nvr';
   }
 
+  function isManagedServiceRecord(rec) {
+    if (!rec || typeof rec !== 'object') return false;
+    if (isGatewayRecord(rec)) return false;
+    const deviceKind = normalizeRole(rec?.deviceKind || rec?.device_kind || '');
+    const service = normalizeRole(rec?.service || '');
+    const hostGatewayPk = String(rec?.hostGatewayPk || rec?.host_gateway_pk || '').trim();
+    const servicePk = String(rec?.servicePk || rec?.service_pk || '').trim();
+    return Boolean(service && service !== 'none' && (deviceKind === 'service' || hostGatewayPk || servicePk));
+  }
+
   function ownedPkSet(identityDevices) {
     return new Set(
       (Array.isArray(identityDevices) ? identityDevices : [])
@@ -108,7 +118,7 @@ export function createManagedApplianceModel({
     if (!gatewayPk) return baseSeen;
     let hostedSeen = 0;
     for (const candidate of Array.isArray(allRecords) ? allRecords : []) {
-      if (!isNvrRecord(candidate)) continue;
+      if (!isManagedServiceRecord(candidate)) continue;
       const hostGatewayPk = String(candidate?.hostGatewayPk || candidate?.host_gateway_pk || '').trim();
       if (!hostGatewayPk || hostGatewayPk !== gatewayPk) continue;
       hostedSeen = Math.max(hostedSeen, applianceSeenAt(candidate));
@@ -155,8 +165,15 @@ export function createManagedApplianceModel({
     return '';
   }
 
+  function looksLikePublicKey(value) {
+    return /^[0-9a-fA-F]{64}$/.test(String(value || '').trim());
+  }
+
   function managedServicePkForRecord(record) {
-    return String(record?.devicePk || record?.pk || '').trim();
+    const explicit = String(record?.servicePk || record?.service_pk || '').trim();
+    if (explicit) return explicit;
+    const fallback = String(record?.devicePk || record?.pk || '').trim();
+    return looksLikePublicKey(fallback) ? fallback : '';
   }
 
   function mergeGatewayHostedServiceRecord(actualRecord, hostedRecord, gatewayRecord) {
@@ -176,6 +193,7 @@ export function createManagedApplianceModel({
     return {
       ...actual,
       devicePk: String(hosted.devicePk || hosted.device_pk || actual.devicePk || actual.pk || '').trim(),
+      servicePk: String(hosted.servicePk || hosted.service_pk || actual.servicePk || actual.service_pk || '').trim(),
       deviceLabel: String(hosted.deviceLabel || hosted.device_label || actual.deviceLabel || actual.label || hosted.service || 'service').trim(),
       deviceKind: String(hosted.deviceKind || hosted.device_kind || actual.deviceKind || actual.device_kind || 'service').trim() || 'service',
       role: String(hosted.service || actual.role || actual.type || '').trim(),
@@ -203,7 +221,7 @@ export function createManagedApplianceModel({
       const rec = applyHostedSnapshot(rawRec);
       const pk = String(rec?.devicePk || rec?.pk || '').trim();
       if (!pk || seen.has(pk)) continue;
-      if (!(isGatewayRecord(rec) || isNvrRecord(rec))) continue;
+      if (!(isGatewayRecord(rec) || isManagedServiceRecord(rec))) continue;
       const ownedRec = owned.has(pk) || owned.has(String(rec?.hostGatewayPk || rec?.host_gateway_pk || '').trim());
       const seenAt = applianceSeenAt(rec);
       const ageMs = seenAt ? Math.max(0, Date.now() - seenAt) : Number.POSITIVE_INFINITY;
@@ -313,6 +331,7 @@ export function createManagedApplianceModel({
     formatAgeShort,
     formatReleaseMeta,
     isGatewayRecord,
+    isManagedServiceRecord,
     isNvrRecord,
     managedGatewayPkForRecord,
     mergeGatewayHostedServiceRecord,

--- a/app/managed-appliances.test.js
+++ b/app/managed-appliances.test.js
@@ -38,6 +38,7 @@ function directNvrRecord(updatedAt) {
 function hostedNvrRecord(updatedAt) {
   return {
     devicePk: 'nvr-pk',
+    servicePk: 'nvr-pk',
     deviceLabel: 'Constitute NVR',
     deviceKind: 'service',
     service: 'nvr',
@@ -46,6 +47,19 @@ function hostedNvrRecord(updatedAt) {
     updatedAt,
     status: 'online',
     cameraCount: 2,
+  };
+}
+
+function directLoggingRecord(updatedAt) {
+  return {
+    devicePk: 'logging-device-pk',
+    servicePk: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+    deviceLabel: 'Constitute Logging',
+    deviceKind: 'service',
+    role: 'native',
+    service: 'logging',
+    hostGatewayPk: 'gateway-pk',
+    updatedAt,
   };
 }
 
@@ -98,4 +112,84 @@ test('direct nvr record remains usable when no gateway-hosted projection exists'
   assert.ok(nvr, 'expected direct nvr record');
   assert.equal(nvr.managedAvailabilityAuthority, undefined);
   assert.equal(model.applianceSeenAt(nvr), now - 45 * 1000);
+});
+
+test('direct generic hosted service record remains usable when no gateway-hosted projection exists', () => {
+  const now = Date.now();
+  const model = makeModel();
+  const recs = model.buildApplianceRecords(
+    [{ pk: 'gateway-pk' }],
+    [directLoggingRecord(now - 30 * 1000)],
+  );
+
+  const logging = recs.find((record) => record.service === 'logging');
+  assert.ok(logging, 'expected direct logging service record');
+  assert.equal(model.isManagedServiceRecord(logging), true);
+  assert.equal(model.managedGatewayPkForRecord(logging), 'gateway-pk');
+  assert.equal(model.managedServicePkForRecord(logging), 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa');
+  assert.equal(model.applianceSeenAt(logging), now - 30 * 1000);
+});
+
+test('gateway freshness considers every hosted service, not only nvr', () => {
+  const now = Date.now();
+  const model = makeModel();
+  const recs = model.buildApplianceRecords(
+    [{ pk: 'gateway-pk' }],
+    [
+      gatewayRecord({ updatedAt: now - 30 * 60 * 1000, hostedServices: [] }),
+      directLoggingRecord(now - 20 * 1000),
+    ],
+  );
+
+  const gateway = recs.find((record) => record.devicePk === 'gateway-pk');
+  assert.ok(gateway, 'expected gateway record');
+  assert.equal(model.effectiveApplianceSeenAt(gateway, recs), now - 20 * 1000);
+});
+
+test('hosted service keeps list identity separate from cryptographic service identity', () => {
+  const now = Date.now();
+  const model = makeModel();
+  const hostedLogging = {
+    devicePk: 'logging:gateway-pk',
+    servicePk: '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
+    deviceLabel: 'Constitute Logging',
+    deviceKind: 'service',
+    service: 'logging',
+    hostGatewayPk: 'gateway-pk',
+    updatedAt: now,
+    status: 'online',
+  };
+  const recs = model.buildApplianceRecords(
+    [{ pk: 'gateway-pk' }],
+    [gatewayRecord({ updatedAt: now, hostedServices: [hostedLogging] })],
+  );
+
+  const logging = recs.find((record) => record.service === 'logging');
+  assert.ok(logging, 'expected hosted logging record');
+  assert.equal(logging.devicePk, 'logging:gateway-pk');
+  assert.equal(model.managedGatewayPkForRecord(logging), 'gateway-pk');
+  assert.equal(model.managedServicePkForRecord(logging), hostedLogging.servicePk);
+});
+
+test('hosted service without service public key does not use synthetic list identity for access', () => {
+  const now = Date.now();
+  const model = makeModel();
+  const hostedLogging = {
+    devicePk: 'logging:gateway-pk',
+    deviceLabel: 'Constitute Logging',
+    deviceKind: 'service',
+    service: 'logging',
+    hostGatewayPk: 'gateway-pk',
+    updatedAt: now,
+    status: 'online',
+  };
+  const recs = model.buildApplianceRecords(
+    [{ pk: 'gateway-pk' }],
+    [gatewayRecord({ updatedAt: now, hostedServices: [hostedLogging] })],
+  );
+
+  const logging = recs.find((record) => record.service === 'logging');
+  assert.ok(logging, 'expected hosted logging record');
+  assert.equal(logging.devicePk, 'logging:gateway-pk');
+  assert.equal(model.managedServicePkForRecord(logging), '');
 });

--- a/app/runtime-projections.test.js
+++ b/app/runtime-projections.test.js
@@ -1,0 +1,95 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const source = readFileSync(resolve(here, '../app.js'), 'utf8');
+const workerSource = readFileSync(resolve(here, '../runtime.worker.js'), 'utf8');
+
+test('logging service projection can discover retained runtime service records before live identity refresh', () => {
+  assert.match(source, /function runtimeOwnedDevicePks\(/);
+  assert.match(source, /\.\.\.runtimeOwnedDevicePks\(\)/);
+  assert.match(source, /findManagedServiceRecordForProjection/);
+  assert.match(source, /managedServicePkForRecord\(rec\)/);
+  assert.match(source, /function retainedProjectionServiceRecord\(/);
+  assert.match(source, /async function discoverManagedServiceRecordForProjection\(/);
+  assert.match(source, /await Promise\.all\(gatewayPks\.map\(\(gatewayPk\) => requestGatewayInventoryRefresh\(gatewayPk, \{ force: true \}\)/);
+  assert.match(source, /runtimeStatusSnapshot\?\.projections/);
+  assert.match(source, /servicePk: projectedService\.servicePk/);
+  assert.match(source, /function withManagedServiceAccessKeys\(/);
+  assert.match(source, /withManagedServiceAccessKeys\(\s+await resolveManagedServiceForAccess\(record, \{ serviceLabel, requireGatewayAuthority: false \}\),\s+record,\s+\)/);
+});
+
+test('logging service projection repair uses bounded timeouts', () => {
+  assert.match(source, /PROJECTION_SERVICE_ACCESS_TIMEOUT_MS/);
+  assert.match(source, /PROJECTION_SIGNAL_REQUEST_TIMEOUT_MS/);
+  assert.match(source, /timeoutMs: PROJECTION_SERVICE_ACCESS_TIMEOUT_MS/);
+  assert.match(source, /timeoutMs: PROJECTION_SIGNAL_REQUEST_TIMEOUT_MS/);
+  assert.match(source, /policy: req\?\.policy && typeof req\.policy === 'object' \? req\.policy : \{\}/);
+});
+
+test('account inventory refresh tracks every managed service surface', () => {
+  assert.match(source, /const MANAGED_APP_SURFACES = Object\.freeze\(\{\s+nvr: 'constitute-nvr-ui',\s+logging: 'constitute-logging-ui',\s+\}\)/);
+  assert.match(source, /Object\.keys\(MANAGED_APP_SURFACES\)\.some\(\(service\) => !findGatewayHostedServiceRecord\(info\.pk, applianceRecords, service\)\)/);
+  assert.doesNotMatch(source, /!findGatewayHostedServiceRecord\(info\.pk, applianceRecords, 'nvr'\)/);
+});
+
+test('account bridge and shared runtime use the same worker build id', () => {
+  assert.match(source, /const PLATFORM_RUNTIME_VERSION = Object\.freeze\(\{ major: 2, minor: 12 \}\)/);
+  assert.match(workerSource, /const RUNTIME_VERSION = Object\.freeze\(\{ major: 2, minor: 12 \}\)/);
+  assert.match(source, /target\.searchParams\.set\('v', PLATFORM_RUNTIME_BUILD_ID\)/);
+  assert.match(source, /name: `constitute-account-runtime-\$\{PLATFORM_RUNTIME_BUILD_ID\}`/);
+});
+
+test('runtime worker does not block local projection and status messages on hydration', () => {
+  assert.doesNotMatch(workerSource, /await ensureHydrated\(\);/);
+  assert.match(workerSource, /A slow gateway\/relay path should\s+\/\/ never make local runtime put\/get messages time out\./);
+  assert.match(workerSource, /case 'runtime\.status\.put':/);
+  assert.match(workerSource, /case 'managedAppliances\.sourceSnapshot\.put':/);
+  assert.match(workerSource, /case BROKER\.PROJECTION_PUT:/);
+  assert.match(workerSource, /case BROKER\.SERVICE_PROJECTION_REQUEST:/);
+});
+
+test('runtime snapshots expose broker availability without leaking request payloads', () => {
+  assert.match(workerSource, /broker: \{\s+available: Boolean\(brokerEndpoint\),\s+surface: String\(brokerEndpoint\?\.surface \|\| ''\)\.trim\(\),\s+\}/);
+  assert.match(workerSource, /const brokerWasAvailable = Boolean\(brokerClientId && endpoints\.get\(brokerClientId\)\)/);
+  assert.match(workerSource, /if \(brokerWasAvailable !== brokerIsAvailable \|\| entry\?\.broker\) \{\s+broadcastSnapshot\(\);\s+scheduleProjectionSync\(0\);\s+\}/);
+  assert.doesNotMatch(workerSource, /broker: \{[^}]*payload/s);
+});
+
+test('runtime worker persists retained projections under service identity keys', () => {
+  assert.match(workerSource, /const key = projectionStoreKey\(stored\) \|\| stored\.channelId/);
+  assert.match(workerSource, /function projectionPolicyId\(/);
+  assert.match(workerSource, /\[servicePk \|\| service, channelId, policyId\]/);
+  assert.match(workerSource, /retainedProjections\.set\(key,/);
+  assert.match(workerSource, /function retainedProjectionObject\(/);
+  assert.match(workerSource, /function retainedProjectionStoreObject\(/);
+  assert.match(workerSource, /function retainedProjectionCoverageObject\(/);
+  assert.match(workerSource, /projections: retainedProjectionStoreObject\(\)/);
+  assert.match(workerSource, /projectionCoverage: retainedProjectionCoverageObject\(\)/);
+  assert.match(workerSource, /function mergeProjectionRecord\(/);
+  assert.match(workerSource, /function mergeProjectionEvents\(/);
+  assert.match(workerSource, /function projectionReplacesEventSet\(/);
+  assert.match(workerSource, /replacesEventSet\s+\?\s+nextEvents\.slice\(\)\.sort/);
+  assert.match(workerSource, /materializedCount: mergedEvents\.length/);
+  assert.match(workerSource, /function projectionSemanticallyEqual\(/);
+  assert.match(workerSource, /if \(existing && projectionSemanticallyEqual\(existing, storedProjection\)\) \{/);
+  assert.match(workerSource, /projection\.observer\.update/);
+  assert.match(workerSource, /result: \{\s+\.\.\.\(message\.result && typeof message\.result === 'object' \? message\.result : \{\}\),\s+projection: stored,/);
+  assert.match(workerSource, /if \(channelId && !out\[channelId\]\) out\[channelId\] = cloned/);
+});
+
+test('runtime worker owns projection policy sync instead of UI request assembly', () => {
+  assert.match(workerSource, /const PROJECTION_POLICY_PUT = 'projection\.policy\.put'/);
+  assert.match(workerSource, /const projectionPolicies = new Map\(\)/);
+  assert.match(workerSource, /const pendingProjectionSyncRequests = new Map\(\)/);
+  assert.match(workerSource, /function handleProjectionPolicyPut\(/);
+  assert.match(workerSource, /function startProjectionSync\(/);
+  assert.match(workerSource, /function queueProjectionSyncRequest\(/);
+  assert.match(workerSource, /sourceClientId: 'runtime-projection-sync'/);
+  assert.match(workerSource, /case PROJECTION_POLICY_PUT:/);
+  assert.match(workerSource, /function handleRuntimeProjectionSyncResponse\(/);
+  assert.match(workerSource, /projection\.sync\.diagnostic/);
+});

--- a/identity/client.js
+++ b/identity/client.js
@@ -11,7 +11,7 @@ import {
   bootControllerMode,
 } from "../app/loading.js";
 
-const SERVICE_WORKER_BUILD_ID = "2026-04-30-broker-ready";
+const SERVICE_WORKER_BUILD_ID = "2026-05-03-servicepk-projection";
 
 function currentServiceWorkerUrl() {
   const target = new URL("./sw.js", window.location.href);

--- a/identity/sw/rpc.js
+++ b/identity/sw/rpc.js
@@ -960,6 +960,21 @@ export async function handleRpc(sw, method, params, getRelayState, setRelayState
     return await blockedRemove({ pk, did });
   }
 
+  async function refreshRelayScopedSubscriptions(ident, openRelayUrls) {
+    const dev = await ensureDevice();
+    await subOpen(sw, ident, (m) => log(sw, m));
+    for (const relayUrl of openRelayUrls) openRelaySubscriptionUrls.add(relayUrl);
+    const nbs = await listZones(ident || {});
+    for (const n of nbs) {
+      await addSelfToZoneList(dev, n.key).catch(() => {});
+      await publishZonePresence(sw, ident, dev, n.key).catch(() => {});
+      const list = await getZoneList(n.key);
+      await publishZoneList(sw, ident, n.key, list.members, list.ts, n.name || "").catch(() => {});
+    }
+    await startPresenceLoop();
+    await startSwarmPublishLoop();
+  }
+
   // --- relay pipe ---
   if (method === 'relay.status') {
     const state = String(params?.state || '');
@@ -984,18 +999,9 @@ export async function handleRpc(sw, method, params, getRelayState, setRelayState
         log(sw, 'relay open; identity-scoped subscriptions deferred until account links');
         return { ok: true };
       }
-      const dev = await ensureDevice();
-      await subOpen(sw, ident, (m) => log(sw, m));
-      for (const relayUrl of openRelayUrls) openRelaySubscriptionUrls.add(relayUrl);
-      const nbs = await listZones(ident || {});
-      for (const n of nbs) {
-        await addSelfToZoneList(dev, n.key).catch(() => {});
-        await publishZonePresence(sw, ident, dev, n.key).catch(() => {});
-        const list = await getZoneList(n.key);
-        await publishZoneList(sw, ident, n.key, list.members, list.ts, n.name || "").catch(() => {});
-      }
-      await startPresenceLoop();
-      await startSwarmPublishLoop();
+      refreshRelayScopedSubscriptions(ident, openRelayUrls).catch((err) => {
+        log(sw, `relay subscription refresh degraded: ${String(err?.message || err)}`);
+      });
     }
     return { ok: true };
   }

--- a/runtime.worker.js
+++ b/runtime.worker.js
@@ -1,11 +1,20 @@
-import { BROKER } from "constitute-protocol";
+import { BROKER, PROJECTION, assertProjectionPolicy, assertProjectionRecord } from "constitute-protocol";
 
-const RUNTIME_VERSION = Object.freeze({ major: 2, minor: 9 });
+const RUNTIME_VERSION = Object.freeze({ major: 2, minor: 12 });
 const RUNTIME_WORKER_BUILD_ID = `runtime-${RUNTIME_VERSION.major}.${RUNTIME_VERSION.minor}`;
 const CONTEXT_TTL_FALLBACK_MS = 2 * 60 * 1000;
 const APPLIANCE_DISCOVERY_MAX_AGE_MS = 60 * 60 * 1000;
 const RUNTIME_STATE_KEY = `runtime.shared.state.v${RUNTIME_VERSION.major}`;
 const RUNTIME_META_KEY = `runtime.shared.meta.v${RUNTIME_VERSION.major}`;
+const PROJECTION_POLICY_PUT = 'projection.policy.put';
+const PROJECTION_SYNC_REQUEST_TIMEOUT_MS = 45_000;
+const PROJECTION_SYNC_RETRY_MS = 5_000;
+const DEFAULT_LOGGING_SYNC_TARGET_COUNT = 2_500;
+const DEFAULT_LOGGING_POLICY_ID = 'logging.default.72h.low';
+const LOGGING_SYNC_CHANNELS = Object.freeze([
+  PROJECTION.CHANNEL.LOGGING_EVENTS,
+  PROJECTION.CHANNEL.LOGGING_HEALTH,
+]);
 
 const DB_NAME = 'constitute_db';
 const DB_VER = 1;
@@ -103,6 +112,16 @@ function isNvrRecord(rec) {
   return role === 'nvr' || service === 'nvr';
 }
 
+function isManagedServiceRecord(rec) {
+  if (!rec || typeof rec !== 'object') return false;
+  if (isGatewayRecord(rec)) return false;
+  const deviceKind = normalizeRole(rec?.deviceKind || rec?.device_kind || '');
+  const service = normalizeRole(rec?.service || '');
+  const hostGatewayPk = String(rec?.hostGatewayPk || rec?.host_gateway_pk || '').trim();
+  const servicePk = String(rec?.servicePk || rec?.service_pk || '').trim();
+  return Boolean(service && service !== 'none' && (deviceKind === 'service' || hostGatewayPk || servicePk));
+}
+
 function ownedPkSet(identityDevices) {
   return new Set(
     (Array.isArray(identityDevices) ? identityDevices : [])
@@ -113,7 +132,10 @@ function ownedPkSet(identityDevices) {
 
 const endpoints = new Map();
 const pendingBrokerRequests = new Map();
+const projectionPolicies = new Map();
+const pendingProjectionSyncRequests = new Map();
 const serviceAccessContexts = new Map();
+const retainedProjections = new Map();
 const runtimeStatus = {
   shell: null,
   services: {},
@@ -139,6 +161,7 @@ let brokerClientId = '';
 let runtimeUpdatedAt = 0;
 let hydratePromise = null;
 let persistTimer = 0;
+let projectionSyncTimer = 0;
 
 function nowMs() {
   return Date.now();
@@ -190,6 +213,442 @@ function touchRuntime() {
 
 function managedServiceAccessContextObject() {
   return Object.fromEntries(Array.from(serviceAccessContexts.entries()).map(([contextId, context]) => [contextId, safeClone(context)]));
+}
+
+function retainedProjectionObject() {
+  const out = {};
+  for (const [key, projection] of retainedProjections.entries()) {
+    const cloned = safeClone(projection);
+    out[key] = cloned;
+    const channelId = String(projection?.channelId || '').trim();
+    if (channelId && !out[channelId]) out[channelId] = cloned;
+    const servicePk = String(projection?.servicePk || projection?.service_pk || '').trim();
+    const service = String(projection?.service || '').trim();
+    if ((servicePk || service) && channelId) {
+      const serviceChannelKey = [servicePk || service, channelId].join('|');
+      if (!out[serviceChannelKey]) out[serviceChannelKey] = cloned;
+    }
+  }
+  return out;
+}
+
+function retainedProjectionStoreObject() {
+  return Object.fromEntries(Array.from(retainedProjections.entries()).map(([key, projection]) => [key, safeClone(projection)]));
+}
+
+function retainedProjectionCoverageObject() {
+  return Object.fromEntries(Array.from(retainedProjections.entries()).map(([key, projection]) => [key, projectionCoverage(projection)]));
+}
+
+function projectionPolicyObject() {
+  return Object.fromEntries(Array.from(projectionPolicies.entries()).map(([key, policy]) => [key, safeClone(policy)]));
+}
+
+function projectionStoreKey(projection) {
+  const servicePk = String(projection?.servicePk || projection?.service_pk || '').trim();
+  const service = String(projection?.service || '').trim();
+  const channelId = String(projection?.channelId || '').trim();
+  const policyId = projectionPolicyId(projection);
+  return [servicePk || service, channelId, policyId].filter(Boolean).join('|');
+}
+
+function projectionPolicyId(projection) {
+  const policy = normalizeObject(projection?.payload?.policy || projection?.scope);
+  return String(projection?.policyId || policy.policyId || 'default').trim();
+}
+
+function projectionPayloadCount(projection) {
+  const payload = projection?.payload;
+  if (Array.isArray(payload)) return payload.length;
+  if (Array.isArray(payload?.events)) return payload.events.length;
+  if (Array.isArray(payload?.items)) return payload.items.length;
+  return 0;
+}
+
+function projectionReplacesEventSet(projection) {
+  return Array.isArray(projection?.payload?.events)
+    && Boolean(projection?.payload?.policy || projection?.scope || projection?.payload?.coverage);
+}
+
+function projectionEventArray(projection) {
+  const events = projection?.payload?.events;
+  return Array.isArray(events) ? events : [];
+}
+
+function projectionEventKey(event) {
+  const direct = String(event?.eventId || event?.event_id || event?.logEventId || event?.id || '').trim();
+  if (direct) return `id:${direct}`;
+  const cursor = String(event?.cursor?.value || event?.cursor || '').trim();
+  if (cursor) return `cursor:${cursor}`;
+  return `shape:${stableJson({
+    occurredAt: event?.occurredAt || event?.occurred_at || event?.ts || '',
+    severity: event?.severity || '',
+    category: event?.category || '',
+    outcome: event?.outcome || '',
+    producer: event?.producer || '',
+    subject: event?.subject || null,
+    resource: event?.resource || null,
+    correlation: event?.correlation || null,
+    tags: event?.tags || [],
+    safeFacts: event?.safeFacts || event?.safe_facts || {},
+  })}`;
+}
+
+function projectionEventTimeSeconds(event) {
+  const raw = Number(event?.occurredAt || event?.occurred_at || event?.ts || event?.timestamp || 0);
+  if (Number.isFinite(raw) && raw > 0) return raw > 9_999_999_999 ? Math.floor(raw / 1000) : raw;
+  const parsed = Date.parse(String(event?.occurredAt || event?.occurred_at || ''));
+  return Number.isFinite(parsed) && parsed > 0 ? Math.floor(parsed / 1000) : 0;
+}
+
+function mergeProjectionEvents(existingEvents, nextEvents) {
+  const byKey = new Map();
+  for (const event of Array.isArray(existingEvents) ? existingEvents : []) {
+    const key = projectionEventKey(event);
+    if (key) byKey.set(key, event);
+  }
+  for (const event of Array.isArray(nextEvents) ? nextEvents : []) {
+    const key = projectionEventKey(event);
+    if (!key) continue;
+    const existing = byKey.get(key);
+    byKey.set(key, existing && typeof existing === 'object'
+      ? { ...existing, ...event }
+      : event);
+  }
+  return Array.from(byKey.values()).sort((left, right) => projectionEventTimeSeconds(right) - projectionEventTimeSeconds(left));
+}
+
+function mergeProjectionRecord(existing, next) {
+  if (!existing || typeof existing !== 'object') return next;
+  if (!next || typeof next !== 'object') return existing;
+  const existingChannel = String(existing?.channelId || '').trim();
+  const nextChannel = String(next?.channelId || '').trim();
+  const sameChannel = existingChannel && existingChannel === nextChannel;
+  const existingServicePk = String(existing?.servicePk || existing?.service_pk || '').trim();
+  const nextServicePk = String(next?.servicePk || next?.service_pk || '').trim();
+  const existingService = String(existing?.service || '').trim();
+  const nextService = String(next?.service || '').trim();
+  const sameService = (existingServicePk || existingService) === (nextServicePk || nextService);
+  if (!sameChannel || !sameService) return next;
+  const merged = {
+    ...existing,
+    ...next,
+    payload: {
+      ...(existing?.payload && typeof existing.payload === 'object' ? existing.payload : {}),
+      ...(next?.payload && typeof next.payload === 'object' ? next.payload : {}),
+    },
+    safeFacts: {
+      ...(existing?.safeFacts && typeof existing.safeFacts === 'object' ? existing.safeFacts : {}),
+      ...(next?.safeFacts && typeof next.safeFacts === 'object' ? next.safeFacts : {}),
+    },
+  };
+  const nextEvents = projectionEventArray(next);
+  const replacesEventSet = projectionReplacesEventSet(next);
+  const mergedEvents = replacesEventSet
+    ? nextEvents.slice().sort((left, right) => projectionEventTimeSeconds(right) - projectionEventTimeSeconds(left))
+    : mergeProjectionEvents(projectionEventArray(existing), nextEvents);
+  if (mergedEvents.length) {
+    const existingCoverage = existing?.payload?.coverage && typeof existing.payload.coverage === 'object' ? existing.payload.coverage : {};
+    const nextCoverage = next?.payload?.coverage && typeof next.payload.coverage === 'object' ? next.payload.coverage : {};
+    const targetCount = Math.max(
+      replacesEventSet ? 0 : Number(existingCoverage.targetCount || 0),
+      Number(nextCoverage.targetCount || 0),
+      mergedEvents.length,
+    );
+    const completionRatio = targetCount > 0 ? Math.min(1, mergedEvents.length / targetCount) : 1;
+    merged.payload = {
+      ...merged.payload,
+      events: mergedEvents,
+      coverage: {
+        ...existingCoverage,
+        ...nextCoverage,
+        materializedCount: mergedEvents.length,
+        targetCount,
+        completionRatio,
+        syncState: completionRatio >= 1 ? 'completeEnough' : String(nextCoverage.syncState || existingCoverage.syncState || 'syncing'),
+      },
+    };
+  }
+  return merged;
+}
+
+function projectionSemanticShape(projection) {
+  const clone = projection && typeof projection === 'object' ? safeClone(projection) : {};
+  delete clone.retainedAt;
+  delete clone.requestId;
+  if (clone.cursor && typeof clone.cursor === 'object') delete clone.cursor.updatedAt;
+  if (clone.freshness && typeof clone.freshness === 'object') {
+    delete clone.freshness.updatedAt;
+    delete clone.freshness.staleAfter;
+  }
+  return clone;
+}
+
+function projectionSemanticallyEqual(left, right) {
+  return stableJson(projectionSemanticShape(left)) === stableJson(projectionSemanticShape(right));
+}
+
+function projectionCoverage(projection) {
+  const coverage = projection?.payload?.coverage && typeof projection.payload.coverage === 'object'
+    ? projection.payload.coverage
+    : {};
+  const materializedCount = projectionPayloadCount(projection);
+  const targetCount = Math.max(Number(coverage.targetCount || 0), materializedCount);
+  const completionRatio = targetCount > 0
+    ? Math.min(1, materializedCount / targetCount)
+    : 1;
+  return {
+    ...safeClone(coverage),
+    materializedCount,
+    targetCount,
+    completionRatio,
+    syncState: String(coverage.syncState || (completionRatio >= 1 ? 'completeEnough' : 'syncing')),
+  };
+}
+
+function projectionFreshness(projection) {
+  const freshness = projection?.freshness && typeof projection.freshness === 'object' ? projection.freshness : {};
+  return {
+    state: String(freshness.state || 'fresh'),
+    updatedAt: Number(freshness.updatedAt || projection?.retainedAt || nowMs()),
+    ...(freshness.staleAfter ? { staleAfter: Number(freshness.staleAfter) } : {}),
+    ...(freshness.reason ? { reason: String(freshness.reason) } : {}),
+  };
+}
+
+function projectionObserverUpdate(projection, changedCount) {
+  return {
+    projectionKey: projectionStoreKey(projection),
+    changedCount: Math.max(0, Number(changedCount || 0)),
+    coverage: projectionCoverage(projection),
+    freshness: projectionFreshness(projection),
+  };
+}
+
+function randomOpaqueId(prefix) {
+  try {
+    const bytes = new Uint8Array(12);
+    self.crypto.getRandomValues(bytes);
+    const token = Array.from(bytes, (value) => value.toString(16).padStart(2, '0')).join('');
+    return `${prefix}-${token}`;
+  } catch {
+    return `${prefix}-${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
+  }
+}
+
+function projectionPolicyStoreKey(policy) {
+  return [
+    String(policy?.service || '').trim(),
+    String(policy?.channelId || '').trim(),
+    String(policy?.policyId || '').trim(),
+  ].filter(Boolean).join('|');
+}
+
+function projectionPolicyForChannel(policy, channelId) {
+  const targetChannelId = String(channelId || policy?.channelId || '').trim();
+  const basePolicyId = String(policy?.policyId || 'default').trim() || 'default';
+  return {
+    ...safeClone(policy),
+    service: String(policy?.service || 'logging').trim() || 'logging',
+    channelId: targetChannelId,
+    policyId: targetChannelId === String(policy?.channelId || '').trim()
+      ? basePolicyId
+      : `${basePolicyId}.${targetChannelId.replace(/[^a-z0-9]+/gi, '.')}`,
+  };
+}
+
+function normalizeProjectionPolicyForRuntime(value) {
+  const raw = value && typeof value === 'object' ? value : {};
+  const policy = {
+    ...safeClone(raw),
+    service: String(raw.service || 'logging').trim() || 'logging',
+    channelId: String(raw.channelId || PROJECTION.CHANNEL.LOGGING_EVENTS).trim(),
+    policyId: String(raw.policyId || DEFAULT_LOGGING_POLICY_ID).trim() || DEFAULT_LOGGING_POLICY_ID,
+    scope: raw.scope && typeof raw.scope === 'object' && !Array.isArray(raw.scope) ? safeClone(raw.scope) : {},
+    syncDepthTarget: raw.syncDepthTarget && typeof raw.syncDepthTarget === 'object' && !Array.isArray(raw.syncDepthTarget)
+      ? safeClone(raw.syncDepthTarget)
+      : { mode: 'policyComplete', targetCount: DEFAULT_LOGGING_SYNC_TARGET_COUNT },
+    retentionTarget: raw.retentionTarget && typeof raw.retentionTarget === 'object' && !Array.isArray(raw.retentionTarget)
+      ? safeClone(raw.retentionTarget)
+      : {},
+  };
+  assertProjectionPolicy(policy);
+  return policy;
+}
+
+function syncTargetCountForPolicy(policy) {
+  const target = Number(policy?.syncDepthTarget?.targetCount || DEFAULT_LOGGING_SYNC_TARGET_COUNT);
+  return Number.isFinite(target) && target > 0 ? Math.min(target, 5_000) : DEFAULT_LOGGING_SYNC_TARGET_COUNT;
+}
+
+function projectionForPolicyChannel(policy, channelId) {
+  const channelPolicy = projectionPolicyForChannel(policy, channelId);
+  const service = String(channelPolicy.service || '').trim();
+  const policyId = String(channelPolicy.policyId || '').trim();
+  const directKey = [service, String(channelPolicy.channelId || '').trim(), policyId].filter(Boolean).join('|');
+  if (retainedProjections.has(directKey)) return retainedProjections.get(directKey);
+  let fallback = null;
+  for (const projection of retainedProjections.values()) {
+    if (String(projection?.service || '').trim() !== service) continue;
+    if (String(projection?.channelId || '').trim() !== String(channelPolicy.channelId || '').trim()) continue;
+    if (projectionPolicyId(projection) === policyId) return projection;
+    if (!fallback || Number(projection?.retainedAt || 0) > Number(fallback?.retainedAt || 0)) {
+      fallback = projection;
+    }
+  }
+  return fallback;
+}
+
+function projectionNeedsRuntimeSync(projection, policy, channelId) {
+  if (!projection) return true;
+  const freshness = projectionFreshness(projection);
+  const staleAfter = Number(freshness.staleAfter || 0);
+  const staleAfterMs = staleAfter > 0 && staleAfter < 9_999_999_999 ? staleAfter * 1000 : staleAfter;
+  if (freshness.state === 'missing' || freshness.state === 'error') return true;
+  if (staleAfterMs && staleAfterMs < nowMs()) return true;
+  if (String(channelId || '') !== PROJECTION.CHANNEL.LOGGING_EVENTS) return false;
+  const coverage = projectionCoverage(projection);
+  const targetCount = syncTargetCountForPolicy(policy);
+  return coverage.materializedCount < Math.min(targetCount, Number(coverage.targetCount || targetCount));
+}
+
+function syncChannelsForPolicy(policy) {
+  const service = String(policy?.service || '').trim();
+  if (service === 'logging') return LOGGING_SYNC_CHANNELS;
+  return [String(policy?.channelId || '').trim()].filter(Boolean);
+}
+
+function broadcastProjectionSyncDiagnostic(operation, detail = {}) {
+  broadcast({
+    type: 'projection.sync.diagnostic',
+    operation,
+    detail: safeClone(detail),
+  });
+}
+
+function scheduleProjectionSync(delayMs = 0) {
+  if (projectionSyncTimer) return;
+  projectionSyncTimer = self.setTimeout(() => {
+    projectionSyncTimer = 0;
+    startProjectionSync();
+  }, Math.max(0, Number(delayMs || 0)));
+}
+
+function startProjectionSync() {
+  const broker = brokerClientId ? endpoints.get(brokerClientId) : null;
+  if (!broker) {
+    if (projectionPolicies.size) {
+      broadcastProjectionSyncDiagnostic('projection.sync.waiting_for_broker', {
+        policyCount: projectionPolicies.size,
+      });
+      scheduleProjectionSync(PROJECTION_SYNC_RETRY_MS);
+    }
+    return;
+  }
+  for (const policy of projectionPolicies.values()) {
+    for (const channelId of syncChannelsForPolicy(policy)) {
+      queueProjectionSyncRequest(policy, channelId, broker);
+    }
+  }
+}
+
+function queueProjectionSyncRequest(policy, channelId, broker) {
+  const channelPolicy = projectionPolicyForChannel(policy, channelId);
+  const pendingKey = projectionPolicyStoreKey(channelPolicy);
+  for (const pending of pendingProjectionSyncRequests.values()) {
+    if (pending.pendingKey === pendingKey) return;
+  }
+  const existing = projectionForPolicyChannel(policy, channelId);
+  if (!projectionNeedsRuntimeSync(existing, channelPolicy, channelId)) return;
+  const requestId = randomOpaqueId('projection');
+  const limit = channelId === PROJECTION.CHANNEL.LOGGING_EVENTS
+    ? syncTargetCountForPolicy(policy)
+    : undefined;
+  const payload = {
+    requestId,
+    channelId,
+    service: String(channelPolicy.service || '').trim(),
+    ...(limit ? { limit } : {}),
+    filters: {},
+    policy: channelPolicy,
+  };
+  const timer = self.setTimeout(() => {
+    pendingProjectionSyncRequests.delete(requestId);
+    broadcastProjectionSyncDiagnostic('projection.sync.degraded', {
+      channelId,
+      requestId,
+      error: 'projection request timed out',
+    });
+    scheduleProjectionSync(PROJECTION_SYNC_RETRY_MS);
+  }, PROJECTION_SYNC_REQUEST_TIMEOUT_MS);
+  pendingProjectionSyncRequests.set(requestId, {
+    pendingKey,
+    channelId,
+    policyId: channelPolicy.policyId,
+    service: channelPolicy.service,
+    createdAt: nowMs(),
+    timer,
+  });
+  broadcastProjectionSyncDiagnostic('projection.sync.request.sent', {
+    channelId,
+    requestId,
+    limit: limit || 0,
+  });
+  endpointPost(broker, {
+    type: 'runtime.broker.request',
+    requestId,
+    kind: BROKER.SERVICE_PROJECTION_REQUEST,
+    payload,
+    sourceClientId: 'runtime-projection-sync',
+  });
+}
+
+function normalizeProjectionRecord(value) {
+  const source = value?.projection && typeof value.projection === 'object' ? value.projection : value;
+  if (!source || typeof source !== 'object') throw new Error('projection result missing');
+  const projection = {
+    ...safeClone(source),
+    channelId: String(source.channelId || '').trim(),
+    service: String(source.service || '').trim(),
+    servicePk: String(source.servicePk || source.service_pk || '').trim(),
+  };
+  assertProjectionRecord(projection);
+  return projection;
+}
+
+function storeProjectionRecord(value) {
+  const projection = normalizeProjectionRecord(value);
+  const key = projectionStoreKey(projection);
+  const existing = retainedProjections.get(key);
+  const existingCount = projectionPayloadCount(existing);
+  const mergedProjection = mergeProjectionRecord(retainedProjections.get(key), projection);
+  const storedProjection = {
+    ...mergedProjection,
+    retainedAt: nowMs(),
+  };
+  if (existing && projectionSemanticallyEqual(existing, storedProjection)) {
+    const refreshedProjection = {
+      ...existing,
+      retainedAt: storedProjection.retainedAt,
+      cursor: storedProjection.cursor || existing.cursor,
+      freshness: storedProjection.freshness || existing.freshness,
+    };
+    retainedProjections.set(key, refreshedProjection);
+    schedulePersist();
+    return safeClone(refreshedProjection);
+  }
+  retainedProjections.set(key, storedProjection);
+  const stored = retainedProjections.get(key);
+  const changedCount = Math.max(0, projectionPayloadCount(stored) - existingCount);
+  touchRuntime();
+  schedulePersist();
+  broadcast({
+    type: 'projection.observer.update',
+    update: projectionObserverUpdate(stored, changedCount),
+    projection: safeClone(stored),
+  });
+  broadcastSnapshot();
+  return safeClone(stored);
 }
 
 function normalizeHostedServices(value) {
@@ -286,7 +745,7 @@ function effectiveApplianceSeenAt(rec, allRecords = []) {
   if (!gatewayPk) return baseSeen;
   let hostedSeen = 0;
   for (const candidate of Array.isArray(allRecords) ? allRecords : []) {
-    if (!isNvrRecord(candidate)) continue;
+    if (!isManagedServiceRecord(candidate)) continue;
     const hostGatewayPk = String(candidate?.hostGatewayPk || candidate?.host_gateway_pk || '').trim();
     if (!hostGatewayPk || hostGatewayPk !== gatewayPk) continue;
     hostedSeen = Math.max(hostedSeen, applianceSeenAt(candidate));
@@ -311,6 +770,7 @@ function mergeGatewayHostedServiceRecord(actualRecord, hostedRecord, gatewayReco
   return {
     ...actual,
     devicePk: String(hosted.devicePk || hosted.device_pk || actual.devicePk || actual.pk || '').trim(),
+    servicePk: String(hosted.servicePk || hosted.service_pk || actual.servicePk || actual.service_pk || '').trim(),
     deviceLabel: String(hosted.deviceLabel || hosted.device_label || actual.deviceLabel || actual.label || hosted.service || 'service').trim(),
     deviceKind: String(hosted.deviceKind || hosted.device_kind || actual.deviceKind || actual.device_kind || 'service').trim() || 'service',
     role: String(hosted.service || actual.role || actual.type || '').trim(),
@@ -338,7 +798,7 @@ function buildApplianceRecords(identityDevices, swarmDevices, grantedRecords = [
     const rec = applyGatewayHostedSnapshot(rawRec);
     const pk = String(rec?.devicePk || rec?.pk || '').trim();
     if (!pk || seen.has(pk)) continue;
-    if (!(isGatewayRecord(rec) || isNvrRecord(rec))) continue;
+    if (!(isGatewayRecord(rec) || isManagedServiceRecord(rec))) continue;
     const ownedRec = owned.has(pk) || owned.has(String(rec?.hostGatewayPk || rec?.host_gateway_pk || '').trim());
     const seenAt = applianceSeenAt(rec);
     const ageMs = seenAt ? Math.max(0, Date.now() - seenAt) : Number.POSITIVE_INFINITY;
@@ -498,14 +958,22 @@ function runtimeSnapshot() {
     touchRuntime();
     schedulePersist();
   }
+  const brokerEndpoint = brokerClientId ? endpoints.get(brokerClientId) : null;
   return {
     buildId: RUNTIME_WORKER_BUILD_ID,
     updatedAt: runtimeUpdatedAt || nowMs(),
+    broker: {
+      available: Boolean(brokerEndpoint),
+      surface: String(brokerEndpoint?.surface || '').trim(),
+    },
     shell: safeClone(runtimeStatus.shell),
     services: safeClone(runtimeStatus.services),
     managedAppliances: safeClone(managedState.applianceSnapshot),
     resourceNames: safeClone(managedState.resourceNames),
     managedServiceIssue: safeClone(managedState.managedServiceIssue),
+    projections: retainedProjectionObject(),
+    projectionCoverage: retainedProjectionCoverageObject(),
+    projectionPolicies: projectionPolicyObject(),
     serviceAccessContextCount: serviceAccessContexts.size,
   };
 }
@@ -573,6 +1041,9 @@ function serializedRuntimeState() {
     managedServiceIssue: safeClone(managedState.managedServiceIssue),
     hostedGatewaySnapshots: safeClone(managedState.hostedGatewaySnapshots),
     serviceAccessContexts: managedServiceAccessContextObject(),
+    projections: retainedProjectionStoreObject(),
+    projectionCoverage: retainedProjectionCoverageObject(),
+    projectionPolicies: projectionPolicyObject(),
   };
 }
 
@@ -642,6 +1113,34 @@ async function hydrateRuntimeState() {
       const key = String(contextId || '').trim();
       if (!key || !context || typeof context !== 'object') continue;
       serviceAccessContexts.set(key, safeClone(context));
+    }
+    retainedProjections.clear();
+    const persistedProjections = payload.projections && typeof payload.projections === 'object'
+      ? payload.projections
+      : {};
+    for (const [channelId, projection] of Object.entries(persistedProjections)) {
+      try {
+        const stored = normalizeProjectionRecord({
+          channelId,
+          ...(projection && typeof projection === 'object' ? projection : {}),
+        });
+        const key = projectionStoreKey(stored) || stored.channelId;
+        const nextProjection = {
+          ...stored,
+          retainedAt: Number(projection?.retainedAt || 0) || Number(stored.freshness?.updatedAt || 0) || nowMs(),
+        };
+        retainedProjections.set(key, mergeProjectionRecord(retainedProjections.get(key), nextProjection));
+      } catch {}
+    }
+    projectionPolicies.clear();
+    const persistedPolicies = payload.projectionPolicies && typeof payload.projectionPolicies === 'object'
+      ? payload.projectionPolicies
+      : {};
+    for (const policy of Object.values(persistedPolicies)) {
+      try {
+        const normalized = normalizeProjectionPolicyForRuntime(policy);
+        projectionPolicies.set(projectionPolicyStoreKey(normalized), normalized);
+      } catch {}
     }
   }
   rebuildManagedApplianceSnapshot();
@@ -743,6 +1242,127 @@ function handleServiceAccessContextDelete(message) {
   return { ok: true, result: { deleted: existed } };
 }
 
+function handleProjectionPut(message) {
+  try {
+    const projection = storeProjectionRecord(message.projection || message.result || message.payload);
+    return { ok: true, result: projection };
+  } catch (error) {
+    return { ok: false, error: String(error?.message || error || 'invalid projection') };
+  }
+}
+
+function handleProjectionGet(message) {
+  const channelId = String(message.channelId || message?.payload?.channelId || '').trim();
+  const servicePk = String(message.servicePk || message?.payload?.servicePk || '').trim();
+  const service = String(message.service || message?.payload?.service || '').trim();
+  const policyId = String(message.policyId || message?.payload?.policyId || '').trim();
+  if (channelId && (servicePk || service || policyId)) {
+    const candidates = [];
+    if (servicePk) candidates.push([servicePk, channelId, policyId || 'default'].filter(Boolean).join('|'));
+    if (service) candidates.push([service, channelId, policyId || 'default'].filter(Boolean).join('|'));
+    for (const candidate of candidates) {
+      if (retainedProjections.has(candidate)) {
+        return { ok: true, result: safeClone(retainedProjections.get(candidate)) };
+      }
+    }
+  }
+  if (channelId) {
+    for (const projection of retainedProjections.values()) {
+      if (String(projection?.channelId || '').trim() === channelId) {
+        return { ok: true, result: safeClone(projection) };
+      }
+    }
+    return { ok: true, result: null };
+  }
+  return { ok: true, result: retainedProjectionObject() };
+}
+
+function handleProjectionPolicyPut(message) {
+  try {
+    const policy = normalizeProjectionPolicyForRuntime(message.policy || message?.payload?.policy || message.payload);
+    const key = projectionPolicyStoreKey(policy);
+    if (!key) return { ok: false, error: 'missing projection policy key' };
+    const existing = projectionPolicies.get(key);
+    projectionPolicies.set(key, policy);
+    touchRuntime();
+    schedulePersist();
+    broadcastSnapshot();
+    broadcastProjectionSyncDiagnostic('projection.policy.applied', {
+      policyId: policy.policyId,
+      service: policy.service,
+      channelId: policy.channelId,
+    });
+    if (stableJson(existing) !== stableJson(policy)) {
+      scheduleProjectionSync(0);
+    }
+    return { ok: true, result: safeClone(policy) };
+  } catch (error) {
+    return { ok: false, error: String(error?.message || error || 'invalid projection policy') };
+  }
+}
+
+function handleRuntimeProjectionSyncResponse(message) {
+  const requestId = String(message.requestId || '').trim();
+  const pending = pendingProjectionSyncRequests.get(requestId);
+  if (!pending) return null;
+  pendingProjectionSyncRequests.delete(requestId);
+  self.clearTimeout(pending.timer);
+  if (message.ok === false) {
+    broadcastProjectionSyncDiagnostic('projection.sync.degraded', {
+      channelId: pending.channelId,
+      requestId,
+      error: String(message.error || 'projection request failed'),
+    });
+    scheduleProjectionSync(PROJECTION_SYNC_RETRY_MS);
+    return { ok: true };
+  }
+  const source = message?.result?.projection || message?.result || null;
+  try {
+    const stored = storeProjectionRecord(source);
+    broadcastProjectionSyncDiagnostic('projection.sync.batch.received', {
+      channelId: pending.channelId,
+      requestId,
+      materialized: projectionCoverage(stored).materializedCount,
+      targetCount: projectionCoverage(stored).targetCount,
+      syncState: projectionCoverage(stored).syncState,
+    });
+    scheduleProjectionSync(250);
+    return { ok: true };
+  } catch (error) {
+    broadcastProjectionSyncDiagnostic('projection.sync.degraded', {
+      channelId: pending.channelId,
+      requestId,
+      error: String(error?.message || error || 'invalid service projection response'),
+    });
+    scheduleProjectionSync(PROJECTION_SYNC_RETRY_MS);
+    return { ok: false, error: String(error?.message || error || 'invalid service projection response') };
+  }
+}
+
+function handleServiceProjectionResponse(message) {
+  const runtimeSyncResult = handleRuntimeProjectionSyncResponse(message);
+  if (runtimeSyncResult) return runtimeSyncResult;
+  const source = message?.result?.projection || message?.result || null;
+  let stored = null;
+  if (message.ok !== false && source && typeof source === 'object') {
+    try {
+      stored = storeProjectionRecord(source);
+    } catch (error) {
+      return { ok: false, error: String(error?.message || error || 'invalid service projection response') };
+    }
+  }
+  const responseMessage = stored
+    ? {
+        ...message,
+        result: {
+          ...(message.result && typeof message.result === 'object' ? message.result : {}),
+          projection: stored,
+        },
+      }
+    : message;
+  return handleBrokerResponse(BROKER.SERVICE_PROJECTION_REQUEST, responseMessage);
+}
+
 function handleManagedSourceSnapshotPut(message) {
   const next = normalizeManagedSourceSnapshot(message.sourceSnapshot);
   if (stableJson(managedState.sourceSnapshot) === stableJson(next)) {
@@ -753,6 +1373,7 @@ function handleManagedSourceSnapshotPut(message) {
   touchRuntime();
   schedulePersist();
   broadcastSnapshot();
+  scheduleProjectionSync(0);
   return { ok: true, result: runtimeSnapshot() };
 }
 
@@ -805,6 +1426,7 @@ async function handleControlMessage(message, endpoint) {
 
   if (type === 'runtime.attach') {
     const clientId = String(message.clientId || '').trim();
+    const brokerWasAvailable = Boolean(brokerClientId && endpoints.get(brokerClientId));
     const entry = ensureEndpoint(clientId, endpoint, {
       surface: message.surface,
       broker: message.broker === true,
@@ -816,10 +1438,18 @@ async function handleControlMessage(message, endpoint) {
       clientId: entry?.clientId || '',
       snapshot: runtimeSnapshot(),
     });
+    const brokerIsAvailable = Boolean(brokerClientId && endpoints.get(brokerClientId));
+    if (brokerWasAvailable !== brokerIsAvailable || entry?.broker) {
+      broadcastSnapshot();
+      scheduleProjectionSync(0);
+    }
     return;
   }
 
-  await ensureHydrated();
+  // Hydration repairs retained state, but it must not gate runtime writes,
+  // broker forwarding, or projection repair. A slow gateway/relay path should
+  // never make local runtime put/get messages time out.
+  startHydrationInBackground();
 
   let response = null;
 
@@ -878,6 +1508,33 @@ async function handleControlMessage(message, endpoint) {
       };
       break;
     }
+    case BROKER.PROJECTION_PUT: {
+      response = {
+        type: 'runtime.response',
+        requestId: String(message.requestId || '').trim(),
+        kind: BROKER.PROJECTION_PUT,
+        ...handleProjectionPut(message),
+      };
+      break;
+    }
+    case BROKER.PROJECTION_GET: {
+      response = {
+        type: 'runtime.response',
+        requestId: String(message.requestId || '').trim(),
+        kind: BROKER.PROJECTION_GET,
+        ...handleProjectionGet(message),
+      };
+      break;
+    }
+    case PROJECTION_POLICY_PUT: {
+      response = {
+        type: 'runtime.response',
+        requestId: String(message.requestId || '').trim(),
+        kind: PROJECTION_POLICY_PUT,
+        ...handleProjectionPolicyPut(message),
+      };
+      break;
+    }
     case 'managedAppliances.sourceSnapshot.put': {
       response = {
         type: 'runtime.response',
@@ -889,6 +1546,7 @@ async function handleControlMessage(message, endpoint) {
     }
     case BROKER.SERVICE_SIGNAL_REQUEST:
     case BROKER.SERVICE_ACCESS_REQUEST:
+    case BROKER.SERVICE_PROJECTION_REQUEST:
     case 'gateway.grant.request':
     case 'gateway.service.install.request':
     case 'gateway.zones.sync.request': {
@@ -908,6 +1566,14 @@ async function handleControlMessage(message, endpoint) {
         type: 'runtime.ack',
         kind: BROKER.SERVICE_SIGNAL_RESPONSE,
         ...handleBrokerResponse(BROKER.SERVICE_SIGNAL_REQUEST, message),
+      };
+      break;
+    }
+    case BROKER.SERVICE_PROJECTION_RESPONSE: {
+      response = {
+        type: 'runtime.ack',
+        kind: BROKER.SERVICE_PROJECTION_RESPONSE,
+        ...handleServiceProjectionResponse(message),
       };
       break;
     }

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 import { startDaemon } from './identity/sw/daemon.js';
 
-const SERVICE_WORKER_BUILD_ID = '2026-04-06-runtime-stage3';
+const SERVICE_WORKER_BUILD_ID = '2026-05-03-servicepk-projection';
 
 self.addEventListener('install', () => self.skipWaiting());
 self.addEventListener('activate', (e) => e.waitUntil(self.clients.claim()));


### PR DESCRIPTION
## Summary
- Adds retained/materialized projection handling in the account runtime.
- Adds projection policy sync and observer behavior for logging projections.
- Preserves shared runtime/service-access boundaries.

## Verification
- npm test
- npm run build