### PR TITLE
fix(account): project pairing expiry state

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -189,6 +189,11 @@ Used for:
 - discovery and zone presence
 - service access/signaling coordination
 
+Pairing UX remains action-oriented:
+- pairing codes can be pasted from operator tools and are normalized before claim
+- pairing claim/request expiry is owned by Service Worker state and projected to UI
+- stale pair requests stop rendering after their advertised TTL
+
 ## Security Model
 - device-level signing remains mandatory
 - Service Worker remains the cryptographic authority for shell state

--- a/app.css
+++ b/app.css
@@ -388,6 +388,17 @@ input[type="checkbox"]{
   animation:bootSpin 0.9s linear infinite;
 }
 
+.pairClaimButton{
+  min-width:5.75rem;
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
+}
+
+.pairClaimButtonSpinner{
+  flex:0 0 auto;
+}
+
 .modal{
   position:fixed;
   inset:50% auto auto 50%;

--- a/app.js
+++ b/app.js
@@ -14,6 +14,7 @@ import {
   shellBootCanDismiss,
 } from './app/loading.js';
 import { createManagedApplianceModel } from './app/managed-appliances.js';
+import { normalizePairCodeInput } from './app/pairing-ui.js';
 
 const ACCOUNT_MAIN_HTML = `
   <section id="viewHome" class="activity hidden">
@@ -54,7 +55,7 @@ const ACCOUNT_MAIN_HTML = `
           <div class="cardTitle">Add Device</div>
           <div class="small muted">Enter the pairing code from a device you want to claim and link to this identity.</div>
           <div class="row u-mt-sm">
-            <input id="pairCodeInput" type="text" placeholder="Enter code from new device" />
+            <input id="pairCodeInput" type="text" inputmode="numeric" autocomplete="one-time-code" placeholder="Enter code from new device" />
             <button id="btnClaimPairCode" type="button">Claim Code</button>
           </div>
           <div id="pairCodeStatus" class="small muted u-mt-sm"></div>
@@ -323,6 +324,7 @@ let lastDirectory = [];
 let lastZones = [];
 let activeZoneKey = '';
 let pendingZoneNav = false;
+let lastPairClaimStatus = null;
 let swarm = null;
 let clientReady = false;
 let swarmBootRequested = false;
@@ -3386,23 +3388,8 @@ function renderNotifications() {
   }
 }
 
-function filterPendingPairRequests(reqs, identityDevices) {
-  const knownPks = new Set((identityDevices || []).map(d => d.pk).filter(Boolean));
-  const knownDids = new Set((identityDevices || []).map(d => d.did).filter(Boolean));
-
-  return (reqs || []).filter(r => {
-    if (r.status && r.status !== 'pending') return false;
-    if (r.state && r.state !== 'pending') return false;
-    if (r.resolved === true) return false;
-    if (r.approved === true || r.rejected === true) return false;
-    if (r.devicePk && knownPks.has(r.devicePk)) return false;
-    if (r.deviceDid && knownDids.has(r.deviceDid)) return false;
-    return true;
-  });
-}
-
 function renderPairRequests(reqs, identityDevices) {
-  const pending = filterPendingPairRequests(reqs, identityDevices);
+  const pending = Array.isArray(reqs) ? reqs : [];
 
   clear(pairingList);
   if (pairingEmpty) pairingEmpty.textContent = 'No pending pairing requests.';
@@ -3470,6 +3457,21 @@ function renderPairRequests(reqs, identityDevices) {
     top.append(left, actions);
     item.append(top);
     pairingList.appendChild(item);
+  }
+}
+
+function renderPairClaimStatus(claimStatus, reqs = []) {
+  const state = String(claimStatus?.state || '').trim();
+  if ((Array.isArray(reqs) && reqs.length > 0) || state === 'matched') {
+    setPairCodeStatus('Pairing request received. Review and approve it below.');
+    return;
+  }
+  if (state === 'expired') {
+    setPairCodeStatus('Pairing code expired. Enter a fresh code from the device.', true);
+    return;
+  }
+  if (state === 'active') {
+    setPairCodeStatus('Claim sent. Wait for the pairing request, then approve it below.');
   }
 }
 
@@ -3824,6 +3826,7 @@ async function refreshExtendedState(core = null) {
   const st = core?.st || lastDeviceState || await client.call('device.getState', {}, { timeoutMs: 20000 });
   const ident = core?.ident || lastIdentity || await client.call('identity.get', {}, { timeoutMs: 20000 });
   const reqs = await client.call('pairing.list', {}, { timeoutMs: 20000 });
+  const pairClaimStatus = await client.call('pairing.claimStatus', {}, { timeoutMs: 20000 }).catch(() => null);
   const blocked = await client.call('blocked.list', {}, { timeoutMs: 20000 });
   const directory = await client.call('directory.list', {}, { timeoutMs: 20000 });
   const zones = await client.call('zones.list', {}, { timeoutMs: 20000 });
@@ -3833,6 +3836,7 @@ async function refreshExtendedState(core = null) {
 
   lastDirectory = directory || [];
   lastZones = zones || [];
+  lastPairClaimStatus = pairClaimStatus || null;
   lastSwarmDevices = swarmDevices || [];
   lastNotifications = Array.isArray(notifs) ? notifs : [];
   notificationsResolved = true;
@@ -3853,6 +3857,7 @@ async function refreshExtendedState(core = null) {
   updateZoneCommandUi();
   pushRuntimeManagedApplianceSourceSnapshot(ident?.devices || [], lastSwarmDevices);
   renderPairRequests(reqs || [], ident?.devices || []);
+  renderPairClaimStatus(lastPairClaimStatus, reqs || []);
   renderNotifications();
 
   const applianceRecords = currentManagedApplianceRecords(ident?.devices || [], lastSwarmDevices);
@@ -4241,15 +4246,39 @@ function wireUi() {
   // settings tabs
   for (const b of tabButtons) b.addEventListener('click', () => setSettingsTab(b.dataset.tab));
 
+  if (pairCodeInput) {
+    pairCodeInput.addEventListener('paste', (event) => {
+      const text = event.clipboardData?.getData('text') || '';
+      const normalized = normalizePairCodeInput(text);
+      if (!normalized) return;
+      event.preventDefault();
+      pairCodeInput.value = normalized;
+      setPairCodeStatus('');
+    });
+    pairCodeInput.addEventListener('input', () => {
+      const normalized = normalizePairCodeInput(pairCodeInput.value);
+      if (normalized !== pairCodeInput.value) pairCodeInput.value = normalized;
+      if (pairCodeStatus?.textContent) setPairCodeStatus('');
+    });
+    pairCodeInput.addEventListener('keydown', (event) => {
+      if (event.key === 'Enter') {
+        event.preventDefault();
+        btnClaimPairCode?.click();
+      }
+    });
+  }
+
   if (btnClaimPairCode) {
     btnClaimPairCode.onclick = async () => {
-      const code = String(pairCodeInput?.value || '').trim();
+      const code = normalizePairCodeInput(pairCodeInput?.value || '');
+      if (pairCodeInput) pairCodeInput.value = code;
       if (!code) {
         setPairCodeStatus('Enter a code from the new device.', true);
         return;
       }
       try {
-        await client.call('pairing.claimCode', { code }, { timeoutMs: 20000 });
+        const claim = await client.call('pairing.claimCode', { code }, { timeoutMs: 20000 });
+        lastPairClaimStatus = { state: 'active', ...claim };
         setPairCodeStatus('Claim sent. Wait for the pairing request, then approve it below.');
       } catch (e) {
         setPairCodeStatus(`Claim failed: ${String(e?.message || e)}`, true);

--- a/app.js
+++ b/app.js
@@ -56,7 +56,10 @@ const ACCOUNT_MAIN_HTML = `
           <div class="small muted">Enter the pairing code from a device you want to claim and link to this identity.</div>
           <div class="row u-mt-sm">
             <input id="pairCodeInput" type="text" inputmode="numeric" autocomplete="one-time-code" placeholder="Enter code from new device" />
-            <button id="btnClaimPairCode" type="button">Claim Code</button>
+            <button id="btnClaimPairCode" class="pairClaimButton" type="button" aria-label="Claim">
+              <span class="pairClaimButtonLabel">Claim</span>
+              <span class="inlineSpinner pairClaimButtonSpinner hidden" aria-hidden="true"></span>
+            </button>
           </div>
           <div id="pairCodeStatus" class="small muted u-mt-sm"></div>
         </div>
@@ -1505,6 +1508,17 @@ function setPairCodeStatus(msg, error = false) {
   if (!pairCodeStatus) return;
   pairCodeStatus.textContent = String(msg || '');
   pairCodeStatus.classList.toggle('warn', !!error);
+}
+
+function setPairClaimButtonBusy(busy) {
+  if (!btnClaimPairCode) return;
+  const label = btnClaimPairCode.querySelector('.pairClaimButtonLabel');
+  const spinner = btnClaimPairCode.querySelector('.pairClaimButtonSpinner');
+  btnClaimPairCode.disabled = !!busy;
+  btnClaimPairCode.setAttribute('aria-busy', busy ? 'true' : 'false');
+  btnClaimPairCode.setAttribute('aria-label', busy ? 'Claiming' : 'Claim');
+  label?.classList.toggle('hidden', !!busy);
+  spinner?.classList.toggle('hidden', !busy);
 }
 
 function setGatewayInstallStatus(msg, error = false) {
@@ -3470,6 +3484,10 @@ function renderPairClaimStatus(claimStatus, reqs = []) {
     setPairCodeStatus('Pairing code expired. Enter a fresh code from the device.', true);
     return;
   }
+  if (state === 'failed') {
+    setPairCodeStatus(String(claimStatus?.message || 'Pairing claim failed. Try again.'), true);
+    return;
+  }
   if (state === 'active') {
     setPairCodeStatus('Claim sent. Wait for the pairing request, then approve it below.');
   }
@@ -4276,12 +4294,16 @@ function wireUi() {
         setPairCodeStatus('Enter a code from the new device.', true);
         return;
       }
+      setPairClaimButtonBusy(true);
+      setPairCodeStatus('');
       try {
         const claim = await client.call('pairing.claimCode', { code }, { timeoutMs: 20000 });
         lastPairClaimStatus = { state: 'active', ...claim };
-        setPairCodeStatus('Claim sent. Wait for the pairing request, then approve it below.');
+        renderPairClaimStatus(lastPairClaimStatus);
       } catch (e) {
         setPairCodeStatus(`Claim failed: ${String(e?.message || e)}`, true);
+      } finally {
+        setPairClaimButtonBusy(false);
       }
     };
   }

--- a/app/pairing-ui.js
+++ b/app/pairing-ui.js
@@ -1,0 +1,8 @@
+export function normalizePairCodeInput(value) {
+  const raw = String(value || '').trim();
+  if (!raw) return '';
+  const exactGroup = raw.match(/(?:^|\D)(\d{6})(?:\D|$)/);
+  if (exactGroup?.[1]) return exactGroup[1];
+  const digits = raw.replace(/\D+/g, '');
+  return digits.slice(0, 6);
+}

--- a/app/pairing-ui.test.js
+++ b/app/pairing-ui.test.js
@@ -1,0 +1,35 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { normalizePairCodeInput } from './pairing-ui.js';
+import {
+  filterPendingPairRequestsForProjection,
+  isPairRequestExpired,
+  pairRequestExpiresAt,
+} from '../identity/sw/pending.js';
+
+test('normalizePairCodeInput accepts pasted operator text', () => {
+  assert.equal(normalizePairCodeInput('209845'), '209845');
+  assert.equal(normalizePairCodeInput('Pairing code: 209845 expires soon'), '209845');
+  assert.equal(normalizePairCodeInput('209 845'), '209845');
+  assert.equal(normalizePairCodeInput('209-845'), '209845');
+});
+
+test('isPairRequestExpired honors request ttl units', () => {
+  assert.equal(pairRequestExpiresAt({ ts: 1_000, ttl: 120 }), 121_000);
+  assert.equal(pairRequestExpiresAt({ ts: 1_000, ttlMs: 500 }), 1_500);
+  assert.equal(isPairRequestExpired({ ts: 1_000, ttl: 120 }, 120_999), false);
+  assert.equal(isPairRequestExpired({ ts: 1_000, ttl: 120 }, 121_001), true);
+  assert.equal(isPairRequestExpired({ ts: 1_000, ttlMs: 500 }, 1_501), true);
+});
+
+test('filterPendingPairRequests removes resolved, known, and expired requests', () => {
+  const now = 300_000;
+  const pending = filterPendingPairRequestsForProjection([
+    { id: 'ok', status: 'pending', devicePk: 'new', ts: now - 1_000, ttl: 120 },
+    { id: 'done', approved: true },
+    { id: 'known', status: 'pending', devicePk: 'known' },
+    { id: 'expired', status: 'pending', ts: now - 200_000, ttl: 120 },
+  ], [{ pk: 'known' }], now);
+  assert.deepEqual(pending.map((request) => request.id), ['ok']);
+});

--- a/identity/sw/pending.js
+++ b/identity/sw/pending.js
@@ -4,6 +4,40 @@ import { kvGet, kvSet } from './idb.js';
 import { getIdentity } from './identityStore.js';
 import { blockedIs } from './blocklist.js';
 
+export function pairRequestExpiresAt(request) {
+  const ts = Number(request?.ts || request?.createdAt || 0);
+  if (!Number.isFinite(ts) || ts <= 0) return 0;
+  const explicitTtlMs = Number(request?.ttlMs || 0);
+  const ttlSeconds = Number(request?.ttl || 0);
+  const ttlMs = Number.isFinite(explicitTtlMs) && explicitTtlMs > 0
+    ? explicitTtlMs
+    : (Number.isFinite(ttlSeconds) && ttlSeconds > 0 ? ttlSeconds * 1000 : 0);
+  return ttlMs > 0 ? ts + ttlMs : 0;
+}
+
+export function isPairRequestExpired(request, nowMs = Date.now()) {
+  const expiresAt = pairRequestExpiresAt(request);
+  if (!expiresAt) return false;
+  return nowMs > expiresAt;
+}
+
+export function filterPendingPairRequestsForProjection(reqs, identityDevices, nowMs = Date.now()) {
+  const knownPks = new Set((identityDevices || []).map((d) => d.pk).filter(Boolean));
+  const knownDids = new Set((identityDevices || []).map((d) => d.did).filter(Boolean));
+
+  return (Array.isArray(reqs) ? reqs : []).flatMap((request) => {
+    const expiresAt = pairRequestExpiresAt(request);
+    if (request.status && request.status !== 'pending') return [];
+    if (request.state && request.state !== 'pending') return [];
+    if (request.resolved === true) return [];
+    if (request.approved === true || request.rejected === true) return [];
+    if (request.devicePk && knownPks.has(request.devicePk)) return [];
+    if (request.deviceDid && knownDids.has(request.deviceDid)) return [];
+    if (isPairRequestExpired(request, nowMs)) return [];
+    return [{ ...request, expiresAt: expiresAt || undefined }];
+  });
+}
+
 export async function pendingAdd(req) {
   const list = (await kvGet('pairPending')) || [];
   if (!list.some(x => x.id === req.id)) list.unshift(req);
@@ -13,18 +47,21 @@ export async function pendingAdd(req) {
 export async function pendingList() {
   const list = (await kvGet('pairPending')) || [];
   const ident = await getIdentity();
-  const known = new Set((ident?.devices || []).map(d => d.pk).filter(Boolean));
 
   // Filter out:
   // - requests for already-known devices (stale)
   // - requests from blocked/rejected/revoked devices
+  // - expired requests according to their projected TTL
   const out = [];
   for (const r of (Array.isArray(list) ? list : [])) {
-    if (r?.devicePk && known.has(r.devicePk)) continue;
     if (await blockedIs({ pk: r?.devicePk, did: r?.deviceDid })) continue;
     out.push(r);
   }
-  return out;
+  const projected = filterPendingPairRequestsForProjection(out, ident?.devices || []);
+  if (projected.length !== (Array.isArray(list) ? list : []).length) {
+    await kvSet('pairPending', projected);
+  }
+  return projected;
 }
 
 export async function pendingRemove(id) {

--- a/identity/sw/relayIn.js
+++ b/identity/sw/relayIn.js
@@ -8,7 +8,7 @@ import { getIdentity, setIdentity } from './identityStore.js';
 import { notifAdd, notifClear, notifRemove } from './notifs.js';
 import { pendingAdd, pendingRemove } from './pending.js';
 import { getSubId, getAppTag } from './relayOut.js';
-import { emit, log, pokeUi } from './uiBus.js';
+import { emit, log, pokeUi, status } from './uiBus.js';
 import { blockedAdd, blockedIs, blockedRemove } from './blocklist.js';
 import { kvGet, kvSet } from './idb.js';
 import { directoryUpsert } from './directory.js';
@@ -22,6 +22,7 @@ const REPLAY_SKEW_SEC = 2 * 60;
 const REPLAY_CAP = 400;
 const PAIR_OFFER_KEY = 'pairOffer';
 const PAIR_CLAIM_ACTIVE_KEY = 'pairClaimActive';
+const PAIR_CLAIM_STATUS_KEY = 'pairClaimStatus';
 
 
 function pairingTags(identityLabel, zones = [], toPk = '') {
@@ -522,6 +523,14 @@ export async function handleRelayFrame(sw, raw) {
       }
       autoApprove = !!activeClaim?.autoApprove;
       await kvSet(PAIR_CLAIM_ACTIVE_KEY, null);
+      await kvSet(PAIR_CLAIM_STATUS_KEY, {
+        state: 'matched',
+        identityLabel: String(payload.identity || '').trim(),
+        claimId: String(activeClaim.claimId || '').trim(),
+        codeHash,
+        matchedAt: nowMs,
+      });
+      status(sw, 'pair request received');
     }
 
     const reqId = String(payload.requestId || '').trim()

--- a/identity/sw/rpc.js
+++ b/identity/sw/rpc.js
@@ -56,14 +56,82 @@ function pairingTags(identityLabel, zones = [], toPk = '') {
 
 const PAIR_OFFER_KEY = 'pairOffer';
 const PAIR_CLAIM_ACTIVE_KEY = 'pairClaimActive';
+const PAIR_CLAIM_STATUS_KEY = 'pairClaimStatus';
 const PAIR_OFFER_TTL_MS = 10 * 60 * 1000;
 const PAIR_CLAIM_TTL_MS = 2 * 60 * 1000;
 const PAIR_CLAIM_MAX_TTL_MS = 10 * 60 * 1000;
+let pairClaimExpiryTimer = null;
 
 async function pairCodeHash(identityLabel, code) {
   return await sha256B64Url(`${String(identityLabel || '').trim()}|${String(code || '').trim()}`);
 }
 
+async function expireActivePairClaim(sw, reason = 'expired') {
+  const claim = (await kvGet(PAIR_CLAIM_ACTIVE_KEY)) || null;
+  if (!claim) return null;
+  const now = Date.now();
+  const expiresAt = Number(claim.expiresAt || 0);
+  if (expiresAt && now < expiresAt && reason === 'expired') return claim;
+  await kvSet(PAIR_CLAIM_ACTIVE_KEY, null);
+  const projected = {
+    state: reason,
+    identityLabel: String(claim.identityLabel || '').trim(),
+    claimId: String(claim.claimId || '').trim(),
+    codeHash: String(claim.codeHash || '').trim(),
+    expiresAt,
+    updatedAt: now,
+  };
+  await kvSet(PAIR_CLAIM_STATUS_KEY, projected);
+  status(sw, reason === 'matched' ? 'pair request received' : 'pair claim expired');
+  pokeUi(sw);
+  return projected;
+}
+
+function schedulePairClaimExpiry(sw, claim) {
+  if (pairClaimExpiryTimer) clearTimeout(pairClaimExpiryTimer);
+  pairClaimExpiryTimer = null;
+  const expiresAt = Number(claim?.expiresAt || 0);
+  if (!expiresAt) return;
+  const delayMs = Math.max(0, expiresAt - Date.now() + 50);
+  pairClaimExpiryTimer = setTimeout(() => {
+    pairClaimExpiryTimer = null;
+    expireActivePairClaim(sw, 'expired').catch((err) => log(sw, `pair claim expiry degraded: ${String(err?.message || err)}`));
+  }, delayMs);
+}
+
+async function projectPairClaimStatus({ consumeExpired = false } = {}) {
+  const claim = (await kvGet(PAIR_CLAIM_ACTIVE_KEY)) || null;
+  const now = Date.now();
+  if (claim) {
+    const expiresAt = Number(claim.expiresAt || 0);
+    if (expiresAt && now > expiresAt) {
+      await kvSet(PAIR_CLAIM_ACTIVE_KEY, null);
+      const projected = {
+        state: 'expired',
+        identityLabel: String(claim.identityLabel || '').trim(),
+        claimId: String(claim.claimId || '').trim(),
+        codeHash: String(claim.codeHash || '').trim(),
+        expiresAt,
+        updatedAt: now,
+      };
+      await kvSet(PAIR_CLAIM_STATUS_KEY, consumeExpired ? null : projected);
+      return projected;
+    }
+    return {
+      state: 'active',
+      identityLabel: String(claim.identityLabel || '').trim(),
+      claimId: String(claim.claimId || '').trim(),
+      codeHash: String(claim.codeHash || '').trim(),
+      autoApprove: !!claim.autoApprove,
+      createdAt: Number(claim.createdAt || 0),
+      expiresAt,
+      updatedAt: now,
+    };
+  }
+  const last = (await kvGet(PAIR_CLAIM_STATUS_KEY)) || null;
+  if (last && consumeExpired) await kvSet(PAIR_CLAIM_STATUS_KEY, null);
+  return last || { state: 'idle', updatedAt: now };
+}
 
 function clampPairClaimTtl(ttlMs) {
   const raw = Number(ttlMs || PAIR_CLAIM_TTL_MS);
@@ -89,6 +157,8 @@ async function activatePairClaim(sw, ident, code, options = {}) {
     createdAt: now,
     expiresAt: now + ttlMs,
   });
+  await kvSet(PAIR_CLAIM_STATUS_KEY, null);
+  schedulePairClaimExpiry(sw, { expiresAt: now + ttlMs });
 
   if (publishClaim) {
     const zones = await listZones(ident || {}).catch(() => []);
@@ -889,6 +959,12 @@ export async function handleRpc(sw, method, params, getRelayState, setRelayState
     return { ok: true, ...claim };
   }
 
+  if (method === 'pairing.claimStatus') {
+    const projected = await projectPairClaimStatus({ consumeExpired: params?.consumeExpired !== false });
+    if (projected?.state === 'active') schedulePairClaimExpiry(sw, projected);
+    return projected;
+  }
+
   if (method === 'pairing.prepareInstall') {
     const ident = await getIdentity();
     if (!ident?.linked || !ident?.label) throw new Error('no linked identity on this device');
@@ -1056,6 +1132,7 @@ export async function handleRpc(sw, method, params, getRelayState, setRelayState
 
     await pendingRemove(rid);
     await notifRemove(`n-pair-${rid}`);
+    await kvSet(PAIR_CLAIM_STATUS_KEY, null);
     status(sw, 'rejected');
     pokeUi(sw);
     return { ok: true };
@@ -1113,6 +1190,7 @@ export async function handleRpc(sw, method, params, getRelayState, setRelayState
 
     await pendingRemove(rid);
     await notifRemove(`n-pair-${rid}`);
+    await kvSet(PAIR_CLAIM_STATUS_KEY, null);
 
     status(sw, 'approved');
     pokeUi(sw);

--- a/identity/sw/rpc.js
+++ b/identity/sw/rpc.js
@@ -87,6 +87,20 @@ async function expireActivePairClaim(sw, reason = 'expired') {
   return projected;
 }
 
+async function projectPairClaimFailure(sw, ident) {
+  await kvSet(PAIR_CLAIM_ACTIVE_KEY, null);
+  const projected = {
+    state: 'failed',
+    identityLabel: String(ident?.label || '').trim(),
+    message: 'Pairing claim failed. Check relay connectivity and try again.',
+    updatedAt: Date.now(),
+  };
+  await kvSet(PAIR_CLAIM_STATUS_KEY, projected);
+  status(sw, 'pair claim failed');
+  pokeUi(sw);
+  return projected;
+}
+
 function schedulePairClaimExpiry(sw, claim) {
   if (pairClaimExpiryTimer) clearTimeout(pairClaimExpiryTimer);
   pairClaimExpiryTimer = null;
@@ -948,11 +962,17 @@ export async function handleRpc(sw, method, params, getRelayState, setRelayState
     const code = String(params?.code || '').trim();
     if (!code) throw new Error('code required');
 
-    const claim = await activatePairClaim(sw, ident, code, {
-      ttlMs: params?.ttlMs,
-      autoApprove: !!params?.autoApprove,
-      publishClaim: params?.publishClaim !== false,
-    });
+    let claim;
+    try {
+      claim = await activatePairClaim(sw, ident, code, {
+        ttlMs: params?.ttlMs,
+        autoApprove: !!params?.autoApprove,
+        publishClaim: params?.publishClaim !== false,
+      });
+    } catch (err) {
+      await projectPairClaimFailure(sw, ident);
+      throw err;
+    }
 
     status(sw, claim.autoApprove ? 'pair claim sent (auto-approve armed)' : 'pair claim sent');
     pokeUi(sw);


### PR DESCRIPTION
## Summary
- Moves pairing claim expiry and pending request expiry into the identity Service Worker state/projection path.
- Keeps account UI responsible only for paste/input normalization and rendering projected pairing state.
- Normalizes pasted six-digit pairing codes from operator text and one-time-code paste flows.

## Verification
- `npm test`
- `npm run build`
- HTTP smoke against `http://localhost:8023/constitute-account/` returned 200 during local verification.

Closes #26