### PR TITLE
Adopt runtime surface posture in Account

### DIFF
--- a/app.js
+++ b/app.js
@@ -35,6 +35,7 @@ import {
   browserStorageShellContext,
   deriveRuntimeShellState,
 } from './runtime-shell-state.js';
+import { accountSurfaceAttachContext } from './surface-app-contract.js';
 
 const ACCOUNT_MAIN_HTML = `
   <section id="viewHome" class="activity hidden">
@@ -2084,6 +2085,7 @@ function startPlatformRuntimeBridge() {
     workerName: runtimeSharedWorkerName(),
     attachTimeoutMs: RUNTIME_ATTACH_TIMEOUT_MS,
     callTimeoutMs: RUNTIME_WRITE_TIMEOUT_MS,
+    attachContext: accountSurfaceAttachContext,
     onPort: (port) => {
       bridge.port = port;
       runtimeDiagnosticsAgent = attachRuntimeDiagnostics({

--- a/app/runtime-swarm-edge.test.js
+++ b/app/runtime-swarm-edge.test.js
@@ -129,7 +129,7 @@ function loadRuntime(store = new Map(), options = {}) {
     });
   }
   const source = `${shellStateSource}\n${raw
-    .replace(/^import[\s\S]*?from "constitute-protocol";/, 'const { SWARM, STREAM_SESSION_LIFECYCLE_PHASE, applyProjectionDelta, assertConsumerFloor, assertEventAdmissionEnvelope, assertMaterializationBudget, assertProjectionDelta, assertProjectionPolicy, assertProjectionRecord, assertProjectionSnapshot, assertResolvedMemberRef, assertProjectionRepairPosture, assertResourcePosture, assertResourceProfile, assertRetentionReleasePosture, assertRoutePromise, assertRuntimeActivationRequest, assertSelfCapabilityAssessment, assertMediaFulfillmentEvidence, assertMediaTransportObservation, assertContributionLifecycle, assertStreamSessionCandidate, assertSubscriptionContract, assertSwarmActivation, assertSwarmFrame, assertSwarmInteraction, makeLogEventEnvelope, openEnvelope, makeProjectionRepairRequest, makeSwarmFrame, pubkeyFromSecretKey, sealEnvelope, eventPlaneForRecordKind, streamSessionLifecycleRecordFromCarrier, streamSessionLifecyclePhase } = __protocol;')
+    .replace(/^import[\s\S]*?from "constitute-protocol";/, 'const { PROJECTION, SERVICE_REGISTRY, SWARM, STREAM_SESSION_LIFECYCLE_PHASE, applyProjectionDelta, assertConsumerFloor, assertEventAdmissionEnvelope, assertMaterializationBudget, assertProjectionDelta, assertProjectionPolicy, assertProjectionRecord, assertProjectionSnapshot, assertResolvedMemberRef, assertProjectionRepairPosture, assertResourcePosture, assertResourceProfile, assertRetentionReleasePosture, assertRoutePromise, assertRuntimeActivationRequest, assertSelfCapabilityAssessment, assertMediaFulfillmentEvidence, assertMediaTransportObservation, assertContributionLifecycle, assertServiceRegistryClaim, assertServiceRegistryMaterialization, assertStreamSessionCandidate, assertSubscriptionContract, assertSwarmActivation, assertSwarmFrame, assertSwarmInteraction, makeLogEventEnvelope, openEnvelope, makeProjectionRepairRequest, makeSwarmFrame, pubkeyFromSecretKey, sealEnvelope, eventPlaneForRecordKind, streamSessionLifecycleRecordFromCarrier, streamSessionLifecyclePhase } = __protocol;')
     .replace(/^import \{ deriveRuntimeShellState \} from "\.\/runtime-shell-state\.js";\s*/m, '')}`;
   const runtimeTimers = makeRuntimeTimers();
   const webSockets = [];
@@ -2747,6 +2747,21 @@ test('runtime stream activation derives route fields from retained service catal
   assert.equal(opened.authority.servicePk, SERVICE_PK);
   assert.equal(opened.authority.gatewayPk, GATEWAY_PK);
   assert.equal(opened.authority.identityId, 'identity-1');
+});
+
+test('runtime service catalog exposes service registry materialization posture', async () => {
+  const runtime = loadRuntime(new Map());
+  await attach(runtime.port);
+  await seedNvrServiceCatalog(runtime.port);
+  await seedNvrEdgeDirectory(runtime.port);
+
+  const catalog = await send(runtime.port, { type: 'service.catalog.get' });
+  assert.equal(catalog.ok, true);
+  assert.equal(catalog.result.registry.kind, protocol.SWARM.RECORD_KIND.SERVICE_REGISTRY_MATERIALIZATION);
+  assert.equal(catalog.result.registry.state, protocol.SERVICE_REGISTRY.MATERIALIZATION_STATE.READY);
+  assert.equal(catalog.result.registry.claimRefs.length, 1);
+  assert.equal(catalog.result.registry.serviceRefs[0], `service:nvr:${SERVICE_PK}`);
+  assert.equal(Array.isArray(catalog.result.registry.entries), true);
 });
 
 test('runtime stream activation resolves NVR source ids through service contract baseline', async () => {

--- a/app/runtime-ui.js
+++ b/app/runtime-ui.js
@@ -1,3 +1,5 @@
+import { preparedServiceRegistry } from '../../constitute-ui/src/service-registry-model.js';
+
 function normalizeArray(value) {
   return Array.isArray(value) ? value : [];
 }
@@ -39,10 +41,8 @@ function serviceHealthLabel(service) {
 }
 
 export function preparedRuntimeServiceCatalog(snapshot = {}) {
-  const catalog = snapshot?.serviceCatalog && typeof snapshot.serviceCatalog === 'object'
-    ? snapshot.serviceCatalog
-    : {};
-  return normalizeArray(catalog.services)
+  const registry = preparedServiceRegistry(snapshot);
+  return normalizeArray(registry.services)
     .filter((service) => service && typeof service === 'object')
     .map((service) => {
       const nodes = normalizeArray(service.nodes)
@@ -126,12 +126,14 @@ export function preparedRuntimeProjectionStatus(snapshot = {}) {
 }
 
 export function buildRuntimeSnapshotView(snapshot = {}) {
+  const serviceRegistry = preparedServiceRegistry(snapshot);
   const catalog = preparedRuntimeServiceCatalog(snapshot);
   const edge = preparedSwarmEdgeStatus(snapshot);
   const projections = preparedRuntimeProjectionStatus(snapshot);
   return {
     catalog,
     catalogLabel: catalog.length === 1 ? '1 service' : `${catalog.length} services`,
+    serviceRegistry,
     edge,
     projections,
   };

--- a/app/runtime-ui.test.js
+++ b/app/runtime-ui.test.js
@@ -69,18 +69,31 @@ test('runtime service catalog view renders retained snapshot services', () => {
   const snapshot = {
     serviceCatalog: {
       updatedAt: 1710000000000,
+      registry: {
+        kind: 'service.registry.materialization',
+        registryId: 'service-registry:runtime',
+        state: 'ready',
+        issuedAt: 1710000000100,
+        claimRefs: ['claim:logging'],
+        services: [
+          {
+            service: 'logging',
+            servicePk: 'abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789',
+            hostGatewayPk: 'gateway-pk',
+            summary: 'Event projection retained.',
+            health: { state: 'ready' },
+            surfaceChannel: 'service.logging.surface',
+            nodes: [
+              { path: 'events', label: 'Events', capabilities: ['projection.observe'] },
+              { path: 'health', label: 'Health', capabilities: ['projection.observe'] },
+            ],
+          },
+        ],
+      },
       services: [
         {
-          service: 'logging',
-          servicePk: 'abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789',
-          hostGatewayPk: 'gateway-pk',
-          summary: 'Event projection retained.',
-          health: { state: 'ready' },
-          surfaceChannel: 'service.logging.surface',
-          nodes: [
-            { path: 'events', label: 'Events', capabilities: ['projection.observe'] },
-            { path: 'health', label: 'Health', capabilities: ['projection.observe'] },
-          ],
+          service: 'legacy',
+          servicePk: 'legacy-pk',
         },
       ],
     },
@@ -90,6 +103,8 @@ test('runtime service catalog view renders retained snapshot services', () => {
   const view = renderRuntimeSnapshotView(elements, snapshot, fakeDocument());
 
   assert.equal(view.catalogLabel, '1 service');
+  assert.equal(view.serviceRegistry.source, 'serviceRegistry');
+  assert.equal(view.serviceRegistry.claimCount, 1);
   assert.equal(elements.catalogStatusEl.textContent, '1 service');
   assert.match(elements.catalogListEl.textContent, /Logging - ready/);
   assert.match(elements.catalogListEl.textContent, /Nodes: Events, Health/);

--- a/app/surface-app-contract.test.js
+++ b/app/surface-app-contract.test.js
@@ -1,0 +1,17 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  accountSurfaceApp,
+  accountSurfaceAttachContext,
+} from "../surface-app-contract.js";
+
+test("account ui declares its surface app modules before runtime attach", () => {
+  assert.equal(accountSurfaceApp.posture.state, "ready");
+  assert.equal(accountSurfaceApp.hasRole("runtimeClient"), true);
+  assert.equal(accountSurfaceApp.hasRole("projectionModel"), true);
+  assert.equal(accountSurfaceApp.hasRole("platformAdapter"), true);
+  assert.equal(accountSurfaceApp.hasRole("productView"), true);
+  assert.equal(accountSurfaceAttachContext.kind, "surface.app.attachContext");
+  assert.equal(accountSurfaceAttachContext.appId, "constitute-account");
+  assert.equal(accountSurfaceAttachContext.moduleRefs.length, 4);
+});

--- a/runtime.worker.js
+++ b/runtime.worker.js
@@ -1,4 +1,6 @@
 import {
+  PROJECTION,
+  SERVICE_REGISTRY,
   SWARM,
   STREAM_SESSION_LIFECYCLE_PHASE,
   applyProjectionDelta,
@@ -9,6 +11,8 @@ import {
   assertProjectionPolicy,
   assertProjectionRecord,
   assertProjectionSnapshot,
+  assertServiceRegistryClaim,
+  assertServiceRegistryMaterialization,
   assertResolvedMemberRef,
   assertProjectionRepairPosture,
   assertResourcePosture,
@@ -6192,6 +6196,130 @@ function serviceDescriptorFromRecord(record) {
   };
 }
 
+function serviceRegistryClaimFromDescriptor(descriptor, issuedAt = nowMs()) {
+  if (!descriptor || typeof descriptor !== 'object') return null;
+  const service = String(descriptor.service || '').trim();
+  const servicePk = String(descriptor.servicePk || '').trim();
+  const hostGatewayPk = String(descriptor.hostGatewayPk || '').trim();
+  if (!service || !servicePk || !hostGatewayPk) return null;
+  const serviceRef = String(descriptor.serviceRef || `service:${service}:${servicePk}`).trim();
+  const zoneScope = normalizeServiceZoneScope(descriptor.zoneScope);
+  const scopeRef = zoneScope?.zoneId ? `zone:${zoneScope.zoneId}` : 'scope:runtime-retained-services';
+  const channelRefs = uniqueTrimmedStrings([
+    descriptor.surfaceChannel,
+    ...normalizeArray(descriptor.nodes).map((node) => node?.channelId || node?.backingChannel),
+  ]);
+  const nodeRefs = uniqueTrimmedStrings(normalizeArray(descriptor.nodes).map((node) => node?.nodeId || node?.path));
+  const capabilityRefs = uniqueTrimmedStrings(normalizeArray(descriptor.nodes).flatMap((node) => normalizeArray(node?.capabilities)));
+  try {
+    return assertServiceRegistryClaim({
+      kind: SWARM.RECORD_KIND.SERVICE_REGISTRY_CLAIM,
+      claimId: `service-registry-claim:${service}:${servicePk}`,
+      schemaVersion: SERVICE_REGISTRY.SCHEMA_VERSION,
+      claimKind: SERVICE_REGISTRY.CLAIM_KIND.SERVICE,
+      state: SERVICE_REGISTRY.CLAIM_STATE.CLAIMED,
+      ownerRef: serviceRef,
+      writerRef: `gateway:${hostGatewayPk}`,
+      subjectRef: serviceRef,
+      scopeRef,
+      service,
+      servicePk,
+      serviceRef,
+      memberRef: descriptor.serviceMemberRef || descriptor.routeMemberRef || servicePk,
+      hostGatewayPk,
+      capabilityRefs,
+      channelRefs,
+      nodeRefs,
+      surfaceRefs: descriptor.surfaceChannel ? [descriptor.surfaceChannel] : [],
+      evidenceRefs: uniqueTrimmedStrings([
+        descriptor.liveEdgeRoute?.memberRef ? `swarm.directory:${descriptor.liveEdgeRoute.memberRef}` : '',
+        descriptor.surfaceChannel ? `projection:${descriptor.surfaceChannel}` : '',
+      ]),
+      safeFacts: { service, surfaceChannel: descriptor.surfaceChannel || '' },
+      issuedAt,
+      expiresAt: issuedAt + 90_000,
+    });
+  } catch (error) {
+    recordRuntimeEvent('service.registry.claim.ignored', {
+      level: 'warn',
+      service,
+      servicePk,
+      error: { message: String(error?.message || error) },
+    });
+    return null;
+  }
+}
+
+function directoryEntriesForServiceRegistry(issuedAt = nowMs()) {
+  const out = [];
+  const seen = new Set();
+  for (const directory of liveDirectoryPayloads()) {
+    for (const entry of normalizeArray(directory.entries)) {
+      const memberRef = String(entry?.memberRef || entry?.member_ref || '').trim();
+      const channelId = String(entry?.channelId || entry?.channel_id || '').trim();
+      const capabilityRef = String(entry?.capabilityRef || entry?.capability || '').trim();
+      const serviceRef = String(entry?.serviceRef || entry?.service_ref || '').trim();
+      const subjectRef = serviceRef || (memberRef ? `member:${memberRef}` : '');
+      if (!subjectRef || !channelId) continue;
+      const entryId = String(entry?.entryId || entry?.entry_id || `directory-entry:${memberRef}:${capabilityRef}:${channelId}`).trim();
+      if (seen.has(entryId)) continue;
+      seen.add(entryId);
+      try {
+        out.push(assertDirectoryEntry({
+          kind: SWARM.RECORD_KIND.DIRECTORY_ENTRY,
+          entryId,
+          subjectRef,
+          source: 'memberRecord',
+          ...(capabilityRef ? { capabilityRef } : {}),
+          channelId,
+          issuedAt: Number(entry?.issuedAt || entry?.issued_at || issuedAt),
+        }));
+      } catch {
+        // Directory entries are an optimization for materialization coverage; invalid
+        // edge claims should not block retained service descriptors.
+      }
+    }
+  }
+  return out;
+}
+
+function serviceRegistryMaterializationFromServices(services, issuedAt = nowMs()) {
+  const registryServices = normalizeArray(services).filter((descriptor) => (
+    String(descriptor?.service || '').trim()
+    && String(descriptor?.servicePk || '').trim()
+    && String(descriptor?.hostGatewayPk || '').trim()
+    && String(descriptor?.surfaceChannel || '').trim()
+  ));
+  const claims = registryServices
+    .map((descriptor) => serviceRegistryClaimFromDescriptor(descriptor, issuedAt))
+    .filter(Boolean);
+  const entries = directoryEntriesForServiceRegistry(issuedAt);
+  const registry = {
+    kind: SWARM.RECORD_KIND.SERVICE_REGISTRY_MATERIALIZATION,
+    registryId: 'service-registry:runtime',
+    schemaVersion: SERVICE_REGISTRY.SCHEMA_VERSION,
+    scopeRef: 'runtime:local',
+    state: claims.length || entries.length
+      ? SERVICE_REGISTRY.MATERIALIZATION_STATE.READY
+      : SERVICE_REGISTRY.MATERIALIZATION_STATE.PARTIAL,
+    revision: issuedAt,
+    claimRefs: claims.map((claim) => claim.claimId),
+    participantRefs: uniqueTrimmedStrings(claims.map((claim) => claim.writerRef)),
+    serviceRefs: uniqueTrimmedStrings(claims.map((claim) => claim.serviceRef)),
+    services: registryServices,
+    entries,
+    coverage: {
+      materializedCount: claims.length,
+      targetCount: claims.length,
+      completionRatio: 1,
+      syncState: PROJECTION.SYNC_STATE.COMPLETE_ENOUGH,
+    },
+    freshness: { state: PROJECTION.FRESHNESS.FRESH, updatedAt: issuedAt },
+    issuedAt,
+  };
+  return assertServiceRegistryMaterialization(registry);
+}
+
 function surfaceFromProjection(projection) {
   const surface = projection?.payload?.surface && typeof projection.payload.surface === 'object'
     ? projection.payload.surface
@@ -6217,6 +6345,7 @@ function retainedSurfaceForDescriptor(descriptor) {
 }
 
 function serviceCatalog() {
+  const updatedAt = runtimeUpdatedAt || nowMs();
   const services = hostedServiceRecords().map((record) => {
     const descriptor = serviceDescriptorFromRecord(record);
     const surface = retainedSurfaceForDescriptor(descriptor);
@@ -6242,8 +6371,9 @@ function serviceCatalog() {
     };
   });
   return {
-    updatedAt: runtimeUpdatedAt || nowMs(),
+    updatedAt,
     services,
+    registry: serviceRegistryMaterializationFromServices(services, updatedAt),
   };
 }
 

--- a/surface-app-contract.js
+++ b/surface-app-contract.js
@@ -1,0 +1,88 @@
+import { SURFACE_APP, assertSurfaceAppContract } from "../constitute-protocol/src/index.js";
+import { defineSurfaceAppContract } from "../constitute-ui/src/surface-app-contract.js";
+
+const ISSUED_AT = 1700000000;
+
+export const accountSurfaceAppContract = assertSurfaceAppContract({
+  contractId: "surface-app:constitute-account",
+  schemaVersion: SURFACE_APP.SCHEMA_VERSION,
+  appId: "constitute-account",
+  appRef: "app:account-ui",
+  version: "0.1.0",
+  displayName: "Account",
+  surfaceRef: "surface:account-ui",
+  requiredPrimitives: [
+    "runtime.attach",
+    "runtime.shell.posture",
+    "projection.materialization",
+  ],
+  requiredModuleRoles: [
+    SURFACE_APP.MODULE_ROLE.RUNTIME_CLIENT,
+    SURFACE_APP.MODULE_ROLE.PROJECTION_MODEL,
+    SURFACE_APP.MODULE_ROLE.PLATFORM_ADAPTER,
+    SURFACE_APP.MODULE_ROLE.PRODUCT_VIEW,
+  ],
+  modules: [
+    {
+      moduleRef: "constitute-ui/runtime-surface-client@0.1.0",
+      role: SURFACE_APP.MODULE_ROLE.RUNTIME_CLIENT,
+      participantSide: SURFACE_APP.PARTICIPANT_SIDE.WINDOW,
+      fulfillmentMode: SURFACE_APP.FULFILLMENT_MODE.BUNDLED,
+      version: "0.1.0",
+      primitiveRefs: ["runtime.attach", "runtime.intent"],
+      inputs: ["runtime.snapshot"],
+      outputs: ["runtime.intent", "runtime.evidence"],
+      issuedAt: ISSUED_AT,
+    },
+    {
+      moduleRef: "constitute-account/runtime-ui-model@0.1.0",
+      role: SURFACE_APP.MODULE_ROLE.PROJECTION_MODEL,
+      participantSide: SURFACE_APP.PARTICIPANT_SIDE.WINDOW,
+      fulfillmentMode: SURFACE_APP.FULFILLMENT_MODE.BUNDLED,
+      version: "0.1.0",
+      primitiveRefs: ["runtime.shell.posture", "projection.materialization"],
+      inputs: ["runtime.snapshot"],
+      outputs: ["account.read-model"],
+      issuedAt: ISSUED_AT,
+    },
+    {
+      moduleRef: "constitute-account/browser-storage-shell@0.1.0",
+      role: SURFACE_APP.MODULE_ROLE.PLATFORM_ADAPTER,
+      participantSide: SURFACE_APP.PARTICIPANT_SIDE.WINDOW,
+      fulfillmentMode: SURFACE_APP.FULFILLMENT_MODE.BUNDLED,
+      version: "0.1.0",
+      primitiveRefs: ["runtime.shell.context"],
+      inputs: ["browser.storage"],
+      outputs: ["shell.context.evidence"],
+      issuedAt: ISSUED_AT,
+    },
+    {
+      moduleRef: "constitute-account/account-view@0.1.0",
+      role: SURFACE_APP.MODULE_ROLE.PRODUCT_VIEW,
+      participantSide: SURFACE_APP.PARTICIPANT_SIDE.WINDOW,
+      fulfillmentMode: SURFACE_APP.FULFILLMENT_MODE.BUNDLED,
+      version: "0.1.0",
+      primitiveRefs: ["runtime.posture.render"],
+      inputs: ["account.read-model", "runtime.shell.posture"],
+      outputs: ["user.intent"],
+      issuedAt: ISSUED_AT,
+    },
+  ],
+  projectionSubscriptions: [
+    { projectionId: "runtime.shell", channelId: "runtime.shell" },
+    { projectionId: "swarm.directory", channelId: "swarm.directory" },
+  ],
+  updatePosture: {
+    state: SURFACE_APP.UPDATE_POSTURE.STATIC,
+    checkedAt: ISSUED_AT,
+  },
+  issuedAt: ISSUED_AT,
+});
+
+export const accountSurfaceApp = defineSurfaceAppContract(accountSurfaceAppContract, {
+  validate: assertSurfaceAppContract,
+});
+
+export const accountSurfaceAttachContext = accountSurfaceApp.attachContext({
+  productSurface: "constitute-account",
+});


### PR DESCRIPTION
Declares the Account surface contract, materializes service registry posture from runtime state, and renders registry posture through the Account UI. This continues the move from Account shell ownership toward Account as a product surface over shared runtime contracts.\n\nValidation: Account tests/build and root docs/convergence/affected/browser/native/check:all passed before branch publication; live surface proof passed against the convergence train.