### PR TITLE
Render account runtime posture

### DIFF
--- a/app.js
+++ b/app.js
@@ -150,6 +150,14 @@ const ACCOUNT_MAIN_HTML = `
           <div class="k">Projection</div>
           <div class="v" id="runtimeProjectionStatus">unknown</div>
         </div>
+        <div class="kv">
+          <div class="k">Resource</div>
+          <div class="v" id="runtimeResourceStatus">unknown</div>
+        </div>
+        <div class="kv">
+          <div class="k">Retention</div>
+          <div class="v" id="runtimeRetentionStatus">unknown</div>
+        </div>
         <div class="small muted" id="runtimeStatusDetail">Runtime snapshot updates automatically.</div>
         <div id="runtimeServiceCatalogList" class="list u-mt-sm"></div>
       </div>
@@ -307,6 +315,8 @@ const runtimeServiceCatalogListEl = document.getElementById('runtimeServiceCatal
 const runtimeEdgeStatusEl = document.getElementById('runtimeEdgeStatus');
 const runtimeQueueStatusEl = document.getElementById('runtimeQueueStatus');
 const runtimeProjectionStatusEl = document.getElementById('runtimeProjectionStatus');
+const runtimeResourceStatusEl = document.getElementById('runtimeResourceStatus');
+const runtimeRetentionStatusEl = document.getElementById('runtimeRetentionStatus');
 const runtimeStatusDetailEl = document.getElementById('runtimeStatusDetail');
 
 const joinDeviceLabelEl = document.getElementById('joinDeviceLabel');
@@ -744,6 +754,8 @@ function renderRuntimeStatusSnapshot() {
     edgeStatusEl: runtimeEdgeStatusEl,
     queueStatusEl: runtimeQueueStatusEl,
     projectionStatusEl: runtimeProjectionStatusEl,
+    resourceStatusEl: runtimeResourceStatusEl,
+    retentionStatusEl: runtimeRetentionStatusEl,
     runtimeStatusDetailEl,
   }, runtimeStatusSnapshot, document);
 }

--- a/app.js
+++ b/app.js
@@ -4,7 +4,6 @@ import {
   renderFirstPartyShell,
   setConnectionStateText,
 } from "constitute-ui";
-import { createRuntimeSurfaceClient } from "../constitute-ui/src/runtime-surface-client.js";
 import { IdentityClient } from './identity/client.js';
 import {
   SHELL_BOOT_FALLBACK_TIMEOUT_MS,
@@ -35,7 +34,10 @@ import {
   browserStorageShellContext,
   deriveRuntimeShellState,
 } from './runtime-shell-state.js';
-import { accountSurfaceAttachContext } from './surface-app-contract.js';
+import {
+  accountRuntimeClientModule,
+  accountSurfaceAttachContext,
+} from './surface-app-contract.js';
 
 const ACCOUNT_MAIN_HTML = `
   <section id="viewHome" class="activity hidden">
@@ -2089,7 +2091,7 @@ function startPlatformRuntimeBridge() {
     return false;
   }
 
-  const runtimeClient = createRuntimeSurfaceClient({
+  const runtimeClient = accountRuntimeClientModule.createRuntimeSurfaceClient({
     clientId,
     surface: 'shell',
     broker: true,

--- a/app/runtime-projections.test.js
+++ b/app/runtime-projections.test.js
@@ -54,7 +54,8 @@ test('account runtime publishes cached swarm service records before identity ref
 });
 
 test('account bridge and shared runtime use the same worker build id', () => {
-  assert.match(source, /createRuntimeSurfaceClient/);
+  assert.match(source, /accountRuntimeClientModule\.createRuntimeSurfaceClient/);
+  assert.doesNotMatch(source, /runtime-surface-client\.js/);
   assert.match(source, /from '\.\/runtime-contract\.js'/);
   assert.match(runtimeContractSource, /PLATFORM_RUNTIME_VERSION = Object\.freeze\(\{ major: 2, minor: 57 \}\)/);
   assert.match(workerSource, /const RUNTIME_VERSION = Object\.freeze\(\{ major: 2, minor: 57 \}\)/);

--- a/app/runtime-shell-state.test.js
+++ b/app/runtime-shell-state.test.js
@@ -29,6 +29,18 @@ test("shell state derives online service posture from edge and retained projecti
     buildId: "runtime-test",
     broker: { available: true },
     edge: { connected: true },
+    resource: {
+      state: "withinBudget",
+      profileId: "balanced",
+      cleanupAllowed: false,
+      cleanupReason: "retention posture must allow release before sweeping",
+    },
+    retention: {
+      state: "releaseRequired",
+      reason: "local release requires explicit retention release posture",
+      releaseRequired: true,
+      destructiveAction: false,
+    },
     shell: {
       identity: { linked: true, identityId: "identity-001", label: "operator" },
     },
@@ -46,6 +58,10 @@ test("shell state derives online service posture from edge and retained projecti
   assert.equal(state.gateway.state, "connected");
   assert.equal(state.services.state, "available");
   assert.equal(state.projections.materialized, true);
+  assert.equal(state.resource.state, "withinBudget");
+  assert.equal(state.resource.cleanupAllowed, false);
+  assert.equal(state.retention.state, "releaseRequired");
+  assert.equal(state.retention.releaseRequired, true);
 });
 
 test("shell state keeps route delivery distinct from adapter live", () => {

--- a/app/runtime-swarm-edge.test.js
+++ b/app/runtime-swarm-edge.test.js
@@ -654,6 +654,10 @@ test('runtime attach declares snapshot materialization budget per surface', asyn
     entry.budgetId === attached.materializationBudget.budgetId
       && entry.clientId === 'surface-materialization-test'
   )), true);
+  assert.equal(snapshot.result.resource.kind, 'runtime.resource.postureSummary');
+  assert.equal(snapshot.result.resource.cleanupAllowed, false);
+  assert.equal(snapshot.result.retention.kind, 'runtime.retention.postureSummary');
+  assert.equal(snapshot.result.retention.releaseRequired, true);
 });
 
 test('runtime diagnostics subscription filters by event plane before replay and delivery', async () => {

--- a/app/runtime-swarm-edge.test.js
+++ b/app/runtime-swarm-edge.test.js
@@ -1132,6 +1132,7 @@ test('runtime reduces media fulfillment evidence as stream posture', async () =>
   });
   assert.equal(pending.ok, true);
   assert.equal(pending.result.state, protocol.SWARM.MEDIA_FULFILLMENT_STATE.PENDING);
+  assert.equal(pending.result.postureState, 'waitingRender');
   assert.equal(pending.result.trackLive, true);
   assert.equal(pending.result.visibleFrame, false);
 
@@ -1156,6 +1157,7 @@ test('runtime reduces media fulfillment evidence as stream posture', async () =>
   });
   assert.equal(visible.ok, true);
   assert.equal(visible.result.state, protocol.SWARM.MEDIA_FULFILLMENT_STATE.USABLE);
+  assert.equal(visible.result.postureState, 'adapterLive');
   assert.equal(visible.result.visibleFrame, true);
 
   const blocked = await send(runtime.port, {
@@ -1176,6 +1178,7 @@ test('runtime reduces media fulfillment evidence as stream posture', async () =>
   });
   assert.equal(blocked.ok, true);
   assert.equal(blocked.result.state, protocol.SWARM.MEDIA_FULFILLMENT_STATE.BLOCKED);
+  assert.equal(blocked.result.postureState, 'mediaPathBlocked');
   assert.deepEqual(blocked.result.blockedReasons, ['iceFailed']);
 
   const snapshot = await send(runtime.port, { type: 'runtime.snapshot.get' });
@@ -1219,10 +1222,11 @@ test('runtime applies media fulfillment posture to owning activation', async () 
   assert.equal(blocked.ok, true);
   let snapshot = await send(runtime.port, { type: 'runtime.snapshot.get' });
   let activation = snapshot.result.activationResolutions['stream-intent-media-fulfillment'];
-  assert.equal(activation.state, 'mediaBlocked');
+  assert.equal(activation.state, 'mediaPathBlocked');
   assert.equal(activation.mediaState, protocol.SWARM.MEDIA_FULFILLMENT_STATE.BLOCKED);
+  assert.equal(activation.mediaPostureState, 'mediaPathBlocked');
   assert.equal(activation.mediaFulfillment.routePromiseId, routePromiseId);
-  assert.equal(activation.lastError.code, 'media.blocked');
+  assert.equal(activation.lastError.code, 'media.pathBlocked');
 
   await send(runtime.port, {
     type: 'runtime.media.fulfillment.evidence.put',
@@ -1263,8 +1267,54 @@ test('runtime applies media fulfillment posture to owning activation', async () 
   activation = snapshot.result.activationResolutions['stream-intent-media-fulfillment'];
   assert.equal(activation.state, 'adapterLive');
   assert.equal(activation.mediaState, protocol.SWARM.MEDIA_FULFILLMENT_STATE.USABLE);
+  assert.equal(activation.mediaPostureState, 'adapterLive');
   assert.equal(activation.lastError, null);
   assert.ok(snapshot.result.runtimeEvents.some((entry) => entry.kind === 'activation.media.fulfillment.applied'));
+});
+
+test('runtime distinguishes render-blocked media posture from path-blocked media posture', async () => {
+  const runtime = loadRuntime(new Map());
+  await attach(runtime.port);
+  const queued = await send(runtime.port, {
+    type: 'swarm.frame.queue',
+    payload: frameInput({
+      correlationId: 'stream-intent-render-blocked',
+      channelId: 'nvr.streams',
+      capability: protocol.SWARM.CORE_CAPABILITY.MEDIA_STREAM_PREVIEW,
+    }),
+  });
+  assert.equal(queued.ok, true);
+  const response = await send(runtime.port, {
+    type: 'runtime.media.fulfillment.evidence.put',
+    payload: {
+      kind: protocol.SWARM.RECORD_KIND.MEDIA_FULFILLMENT_EVIDENCE,
+      evidenceId: 'media-proof-render-blocked',
+      evidenceKind: protocol.SWARM.MEDIA_FULFILLMENT_EVIDENCE_KIND.RENDER_STATE,
+      state: protocol.SWARM.MEDIA_FULFILLMENT_STATE.BLOCKED,
+      blockedReason: 'renderPlaybackStalled',
+      correlationId: queued.result.frameId,
+      routePromiseId: 'route:stream-intent-render-blocked',
+      adapterRef: 'adapter:media-webrtc:browser',
+      safeFacts: {
+        readinessState: 'renderBlocked',
+        videoWidth: 640,
+        videoHeight: 360,
+        visibleFrame: true,
+        playbackAdvanced: false,
+      },
+      observedAt: 1_700_000_007,
+      expiresAt: 1_700_060_007,
+    },
+  });
+  assert.equal(response.ok, true);
+  assert.equal(response.result.state, protocol.SWARM.MEDIA_FULFILLMENT_STATE.BLOCKED);
+  assert.equal(response.result.postureState, 'renderBlocked');
+  assert.equal(response.result.blockedCategory, 'render');
+  const snapshot = await send(runtime.port, { type: 'runtime.snapshot.get' });
+  const activation = snapshot.result.activationResolutions['stream-intent-render-blocked'];
+  assert.equal(activation.state, 'renderBlocked');
+  assert.equal(activation.mediaPostureState, 'renderBlocked');
+  assert.equal(activation.lastError.code, 'media.renderBlocked');
 });
 
 test('runtime reduces service media transport observations into stream fulfillment posture', async () => {
@@ -1319,6 +1369,7 @@ test('runtime reduces service media transport observations into stream fulfillme
   assert.equal(received.ok, true, JSON.stringify(received));
   const posture = received.result.mediaFulfillment['nvr-preview-service-observation'];
   assert.equal(posture.state, protocol.SWARM.MEDIA_FULFILLMENT_STATE.BLOCKED);
+  assert.equal(posture.postureState, 'mediaPathBlocked');
   assert.equal(posture.serviceRef, `service:${SERVICE_PK}`);
   assert.deepEqual(posture.blockedReasons, ['peerConnectionFailed']);
   assert.equal(posture.latestEvidence.safeFacts.observationState, protocol.SWARM.MEDIA_TRANSPORT_OBSERVATION_STATE.FAILED);
@@ -1360,6 +1411,7 @@ test('runtime accepts browser media transport observations as shared stream post
 
   assert.equal(response.ok, true, JSON.stringify(response));
   assert.equal(response.result.state, protocol.SWARM.MEDIA_FULFILLMENT_STATE.BLOCKED);
+  assert.equal(response.result.postureState, 'mediaPathBlocked');
   assert.equal(response.result.adapterRef, 'adapter:media-webrtc:browser');
   assert.deepEqual(response.result.blockedReasons, ['inboundRtpStalled']);
   const snapshot = await send(runtime.port, { type: 'runtime.snapshot.get' });

--- a/app/runtime-ui.js
+++ b/app/runtime-ui.js
@@ -125,17 +125,33 @@ export function preparedRuntimeProjectionStatus(snapshot = {}) {
   };
 }
 
+function preparedPostureStatus(posture = {}, fallbackState = 'unknown') {
+  const state = text(posture?.state || fallbackState) || fallbackState;
+  const reason = text(posture?.cleanupReason || posture?.reason || posture?.blockedReason);
+  return {
+    state,
+    label: reason ? `${state} / ${reason}` : state,
+    reason,
+    cleanupAllowed: posture?.cleanupAllowed === true,
+    releaseRequired: posture?.releaseRequired === true,
+  };
+}
+
 export function buildRuntimeSnapshotView(snapshot = {}) {
   const serviceRegistry = preparedServiceRegistry(snapshot);
   const catalog = preparedRuntimeServiceCatalog(snapshot);
   const edge = preparedSwarmEdgeStatus(snapshot);
   const projections = preparedRuntimeProjectionStatus(snapshot);
+  const resource = preparedPostureStatus(snapshot?.resource, 'unknown');
+  const retention = preparedPostureStatus(snapshot?.retention, 'unknown');
   return {
     catalog,
     catalogLabel: catalog.length === 1 ? '1 service' : `${catalog.length} services`,
     serviceRegistry,
     edge,
     projections,
+    resource,
+    retention,
   };
 }
 
@@ -186,10 +202,15 @@ export function renderRuntimeSnapshotView(elements, snapshot = {}, documentRef =
   if (elements.edgeStatusEl) elements.edgeStatusEl.textContent = view.edge.edgeLabel;
   if (elements.queueStatusEl) elements.queueStatusEl.textContent = view.edge.queueLabel;
   if (elements.projectionStatusEl) elements.projectionStatusEl.textContent = view.projections.label;
+  if (elements.resourceStatusEl) elements.resourceStatusEl.textContent = view.resource.label;
+  if (elements.retentionStatusEl) elements.retentionStatusEl.textContent = view.retention.label;
   if (elements.runtimeStatusDetailEl) {
-    elements.runtimeStatusDetailEl.textContent = view.edge.rejectMessage
-      ? `Last reject: ${view.edge.rejectMessage}`
-      : 'Runtime snapshot updates automatically.';
+    const detail = [
+      view.edge.rejectMessage ? `Last reject: ${view.edge.rejectMessage}` : '',
+      view.resource.reason ? `Resource: ${view.resource.reason}` : '',
+      view.retention.reason ? `Retention: ${view.retention.reason}` : '',
+    ].filter(Boolean).join(' / ');
+    elements.runtimeStatusDetailEl.textContent = detail || 'Runtime snapshot updates automatically.';
   }
   return view;
 }

--- a/app/runtime-ui.test.js
+++ b/app/runtime-ui.test.js
@@ -61,6 +61,8 @@ function runtimeElements() {
     edgeStatusEl: new FakeElement(),
     queueStatusEl: new FakeElement(),
     projectionStatusEl: new FakeElement(),
+    resourceStatusEl: new FakeElement(),
+    retentionStatusEl: new FakeElement(),
     runtimeStatusDetailEl: new FakeElement(),
   };
 }
@@ -161,6 +163,16 @@ test('swarm edge queue reject and repair status renders from snapshot', () => {
     projectionCoverage: {
       'logging.events': { materializedCount: 42 },
     },
+    resource: {
+      state: 'withinBudget',
+      cleanupAllowed: false,
+      cleanupReason: 'retention posture must allow release before sweeping',
+    },
+    retention: {
+      state: 'releaseRequired',
+      releaseRequired: true,
+      reason: 'retention blockers active',
+    },
   };
   const view = buildRuntimeSnapshotView(snapshot);
   const elements = runtimeElements();
@@ -171,7 +183,12 @@ test('swarm edge queue reject and repair status renders from snapshot', () => {
   assert.equal(elements.edgeStatusEl.textContent, 'fixture offline');
   assert.equal(elements.queueStatusEl.textContent, '2 queued / 1 rejected / 1 repair');
   assert.equal(elements.projectionStatusEl.textContent, '1 retained / 42 records');
-  assert.equal(elements.runtimeStatusDetailEl.textContent, 'Last reject: revision gap');
+  assert.equal(elements.resourceStatusEl.textContent, 'withinBudget / retention posture must allow release before sweeping');
+  assert.equal(elements.retentionStatusEl.textContent, 'releaseRequired / retention blockers active');
+  assert.equal(
+    elements.runtimeStatusDetailEl.textContent,
+    'Last reject: revision gap / Resource: retention posture must allow release before sweeping / Retention: retention blockers active',
+  );
 });
 
 test('active form input survives background runtime snapshot render', () => {

--- a/app/surface-app-contract.test.js
+++ b/app/surface-app-contract.test.js
@@ -1,8 +1,11 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import {
+  accountRuntimeClientModule,
   accountSurfaceApp,
   accountSurfaceAttachContext,
+  accountSurfaceModuleRegistry,
+  accountSurfaceModules,
 } from "../surface-app-contract.js";
 
 test("account ui declares its surface app modules before runtime attach", () => {
@@ -11,6 +14,9 @@ test("account ui declares its surface app modules before runtime attach", () => 
   assert.equal(accountSurfaceApp.hasRole("projectionModel"), true);
   assert.equal(accountSurfaceApp.hasRole("platformAdapter"), true);
   assert.equal(accountSurfaceApp.hasRole("productView"), true);
+  assert.equal(accountSurfaceModuleRegistry.kind, "surface.module.registry");
+  assert.equal(accountSurfaceModules.state, "ready");
+  assert.equal(typeof accountRuntimeClientModule.createRuntimeSurfaceClient, "function");
   assert.equal(accountSurfaceAttachContext.kind, "surface.app.attachContext");
   assert.equal(accountSurfaceAttachContext.appId, "constitute-account");
   assert.equal(accountSurfaceAttachContext.moduleRefs.length, 4);

--- a/package-lock.json
+++ b/package-lock.json
@@ -864,7 +864,7 @@
     },
     "node_modules/constitute-ui": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/Aux0x7F/constitute-ui.git#0af1d29f85c225b567d2ced4f2487b29efc41a9d"
+      "resolved": "git+ssh://git@github.com/Aux0x7F/constitute-ui.git#0c739a1b4200214487c40e69fb12d7de19f95633"
     },
     "node_modules/esbuild": {
       "version": "0.25.12",

--- a/package-lock.json
+++ b/package-lock.json
@@ -864,7 +864,7 @@
     },
     "node_modules/constitute-ui": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/Aux0x7F/constitute-ui.git#0c739a1b4200214487c40e69fb12d7de19f95633"
+      "resolved": "git+ssh://git@github.com/Aux0x7F/constitute-ui.git#166d55d1c05f2b4ef4db898f6fa74c036489fa54"
     },
     "node_modules/esbuild": {
       "version": "0.25.12",

--- a/package-lock.json
+++ b/package-lock.json
@@ -864,7 +864,7 @@
     },
     "node_modules/constitute-ui": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/Aux0x7F/constitute-ui.git#166d55d1c05f2b4ef4db898f6fa74c036489fa54"
+      "resolved": "git+ssh://git@github.com/Aux0x7F/constitute-ui.git#007318f482c1259e67c49e1cc40bc2dee3604b3a"
     },
     "node_modules/esbuild": {
       "version": "0.25.12",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,8 @@
       "name": "constitute-account",
       "version": "0.1.0",
       "dependencies": {
-        "constitute-protocol": "github:Aux0x7F/constitute-protocol#codex/swarm-runtime-convergence-protocol",
-        "constitute-ui": "github:Aux0x7F/constitute-ui#codex/surface-sdk-boundary-20260517"
+        "constitute-protocol": "github:Aux0x7F/constitute-protocol#main",
+        "constitute-ui": "github:Aux0x7F/constitute-ui#main"
       },
       "devDependencies": {
         "vite": "^6.2.0"
@@ -855,7 +855,7 @@
     },
     "node_modules/constitute-protocol": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/Aux0x7F/constitute-protocol.git#ab3f739ffcf53c1e1e594e36bbe458b5233ef822",
+      "resolved": "git+ssh://git@github.com/Aux0x7F/constitute-protocol.git#3a452b5f9482f28ebd07f17549cba15b6355d530",
       "dependencies": {
         "@noble/ciphers": "^1.3.0",
         "@noble/curves": "^1.9.1",
@@ -864,7 +864,7 @@
     },
     "node_modules/constitute-ui": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/Aux0x7F/constitute-ui.git#007318f482c1259e67c49e1cc40bc2dee3604b3a"
+      "resolved": "git+ssh://git@github.com/Aux0x7F/constitute-ui.git#3a677aa320282325b8def8be82473279bd70e0b8"
     },
     "node_modules/esbuild": {
       "version": "0.25.12",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "constitute-protocol": "github:Aux0x7F/constitute-protocol#codex/swarm-runtime-convergence-protocol",
-        "constitute-ui": "github:Aux0x7F/constitute-ui#codex/swarm-runtime-convergence-ui"
+        "constitute-ui": "github:Aux0x7F/constitute-ui#codex/surface-sdk-boundary-20260517"
       },
       "devDependencies": {
         "vite": "^6.2.0"
@@ -864,7 +864,7 @@
     },
     "node_modules/constitute-ui": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/Aux0x7F/constitute-ui.git#ead823d8d8271cfaf19c021c7a675c224d9d4912"
+      "resolved": "git+ssh://git@github.com/Aux0x7F/constitute-ui.git#0af1d29f85c225b567d2ced4f2487b29efc41a9d"
     },
     "node_modules/esbuild": {
       "version": "0.25.12",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "constitute-protocol": "github:Aux0x7F/constitute-protocol#codex/swarm-runtime-convergence-protocol",
-    "constitute-ui": "github:Aux0x7F/constitute-ui#codex/swarm-runtime-convergence-ui"
+    "constitute-ui": "github:Aux0x7F/constitute-ui#codex/surface-sdk-boundary-20260517"
   },
   "devDependencies": {
     "vite": "^6.2.0"

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
     "test": "node --test app/**/*.test.js"
   },
   "dependencies": {
-    "constitute-protocol": "github:Aux0x7F/constitute-protocol#codex/swarm-runtime-convergence-protocol",
-    "constitute-ui": "github:Aux0x7F/constitute-ui#codex/surface-sdk-boundary-20260517"
+    "constitute-protocol": "github:Aux0x7F/constitute-protocol#main",
+    "constitute-ui": "github:Aux0x7F/constitute-ui#main"
   },
   "devDependencies": {
     "vite": "^6.2.0"

--- a/runtime-shell-state.js
+++ b/runtime-shell-state.js
@@ -199,6 +199,8 @@ export function deriveRuntimeShellState(snapshot = {}, options = {}) {
   const edge = record(snap.edge);
   const broker = record(snap.broker);
   const authority = record(snap.authority);
+  const resource = record(snap.resource);
+  const retention = record(snap.retention);
 
   const identityId = firstText(
     identity.identityId,
@@ -350,6 +352,19 @@ export function deriveRuntimeShellState(snapshot = {}, options = {}) {
       count: projectionCount(snap),
       materialized: projectionMaterialized,
       freshness: projectionMaterialized ? "materialized" : "missing",
+    }),
+    resource: Object.freeze({
+      state: firstText(resource.state, "unknown"),
+      reason: firstText(resource.reason),
+      profileId: firstText(resource.profileId),
+      cleanupAllowed: resource.cleanupAllowed === true,
+      cleanupReason: firstText(resource.cleanupReason),
+    }),
+    retention: Object.freeze({
+      state: firstText(retention.state, "unknown"),
+      reason: firstText(retention.reason),
+      releaseRequired: retention.releaseRequired !== false,
+      destructiveAction: retention.destructiveAction === true,
     }),
     interaction: Object.freeze({
       routeDelivered,

--- a/runtime.worker.js
+++ b/runtime.worker.js
@@ -2213,6 +2213,7 @@ function activationResolutionObject() {
       ? entry.mediaFulfillment
       : null;
     const mediaState = String(mediaFulfillment?.state || '').trim();
+    const mediaPostureState = String(mediaFulfillment?.postureState || '').trim();
     const recordKind = queuedSwarmFrameRecordKind(entry);
     const rawState = String(routeObservation?.state || entry.status || 'queued').trim() || 'queued';
     const admissionTimedOut = String(entry.status || '').trim() === 'serviceAdmissionTimedOut';
@@ -2220,12 +2221,14 @@ function activationResolutionObject() {
     const state = entry.serviceRejected
       ? 'serviceRejected'
       : mediaState === SWARM.MEDIA_FULFILLMENT_STATE.BLOCKED
-        ? 'mediaBlocked'
+        ? mediaPostureState || 'mediaBlocked'
         : mediaState === SWARM.MEDIA_FULFILLMENT_STATE.RELEASED
           ? 'released'
           : mediaState === SWARM.MEDIA_FULFILLMENT_STATE.USABLE
             ? 'adapterLive'
-            : entry.serviceAnswer
+            : mediaState === SWARM.MEDIA_FULFILLMENT_STATE.PENDING && mediaPostureState === 'waitingRender'
+              ? 'waitingRender'
+              : entry.serviceAnswer
               ? 'answerMaterialized'
             : entry.serviceAccepted
               ? 'waitingServiceAnswer'
@@ -2262,6 +2265,7 @@ function activationResolutionObject() {
       contributionWitnessedAt: Number(entry.contributionWitnessedAt || 0) || 0,
       mediaFulfillment: mediaFulfillment ? safeClone(mediaFulfillment) : null,
       mediaState,
+      mediaPostureState,
       responseState: signalDeliveryState ? 'notRequired' : entry.serviceRejected ? 'rejected' : entry.serviceAnswer ? 'materialized' : entry.serviceAccepted ? 'waitingServiceAnswer' : admissionTimedOut ? 'serviceAdmissionTimedOut' : '',
       lastError: entry.lastError ? safeClone(entry.lastError) : null,
       updatedAt: Number(entry.mediaFulfillmentAt || entry.contributionWitnessedAt || entry.serviceAnswerAt || entry.serviceAcceptedAt || entry.serviceAdmissionTimedOutAt || entry.routeObservedAt || entry.rejectedAt || entry.ackedAt || entry.sentAt || entry.queuedAt || 0),
@@ -3247,6 +3251,10 @@ function fulfillmentEvidenceFromTransportObservation(record, openedFrame) {
     participantRole: String(record.participantRole || '').trim(),
     observationState: String(record.state || '').trim(),
     connectionState: String(record.connectionState || '').trim(),
+    iceConnectionState: String(record.iceConnectionState || '').trim(),
+    selectedPairState: String(record.selectedPairState || '').trim(),
+    inboundRtpState: String(record.inboundRtpState || '').trim(),
+    renderState: String(record.renderState || '').trim(),
     reason: String(record.reason || '').trim(),
   };
   const evidence = {
@@ -8219,10 +8227,16 @@ function mediaFulfillmentEntrySnapshot(entry) {
     serviceRef: entry.serviceRef,
     routePromiseId: entry.routePromiseId,
     state: entry.state,
+    postureState: entry.postureState,
+    blockedCategory: entry.blockedCategory || '',
     blockedReasons: entry.blockedReasons.slice(),
     visibleFrame: entry.visibleFrame === true,
     trackLive: entry.trackLive === true,
     transportUsable: entry.transportUsable === true,
+    renderReadinessState: entry.renderReadinessState || '',
+    selectedPairState: entry.selectedPairState || '',
+    inboundRtpState: entry.inboundRtpState || '',
+    renderState: entry.renderState || '',
     updatedAt: entry.updatedAt,
     expiresAt: entry.expiresAt || undefined,
     latestEvidence: safeClone(entry.latestEvidence || null),
@@ -8234,6 +8248,85 @@ function mediaFulfillmentObject() {
   return Object.fromEntries(
     Array.from(mediaFulfillmentPostures.entries()).map(([key, entry]) => [key, mediaFulfillmentEntrySnapshot(entry)]),
   );
+}
+
+function mediaEvidenceSafeFacts(record) {
+  return record?.safeFacts && typeof record.safeFacts === 'object' ? record.safeFacts : {};
+}
+
+function mediaBlockedCategory(reason, evidenceKind, facts = {}) {
+  const normalizedReason = String(reason || '').trim();
+  const readinessState = String(facts.readinessState || '').trim();
+  if (
+    evidenceKind === SWARM.MEDIA_FULFILLMENT_EVIDENCE_KIND.RENDER_STATE
+    || readinessState === 'renderBlocked'
+    || [
+      'renderPlaybackStalled',
+      'renderDimensionsMissing',
+      'videoElementError',
+    ].includes(normalizedReason)
+  ) {
+    return 'render';
+  }
+  if (
+    evidenceKind === SWARM.MEDIA_FULFILLMENT_EVIDENCE_KIND.TRANSPORT_STATE
+    || evidenceKind === SWARM.MEDIA_FULFILLMENT_EVIDENCE_KIND.SELECTED_CANDIDATE_PAIR
+    || evidenceKind === SWARM.MEDIA_FULFILLMENT_EVIDENCE_KIND.INBOUND_STATS
+    || [
+      'iceFailed',
+      'peerConnectionFailed',
+      'inboundRtpStalled',
+      'mediaTransportBlocked',
+      'missingBrowserCandidate',
+      'missingServiceCandidate',
+    ].includes(normalizedReason)
+  ) {
+    return 'mediaPath';
+  }
+  if (evidenceKind === SWARM.MEDIA_FULFILLMENT_EVIDENCE_KIND.TRACK_STATE) return 'track';
+  return normalizedReason ? 'media' : '';
+}
+
+function mediaRuntimePostureState(entry) {
+  const latestEvidence = entry.latestEvidence || {};
+  const latestFacts = mediaEvidenceSafeFacts(latestEvidence);
+  const latestKind = String(latestEvidence.evidenceKind || '').trim();
+  const render = entry.evidenceByKind.get(SWARM.MEDIA_FULFILLMENT_EVIDENCE_KIND.RENDER_STATE);
+  const renderFacts = mediaEvidenceSafeFacts(render);
+  const inbound = entry.evidenceByKind.get(SWARM.MEDIA_FULFILLMENT_EVIDENCE_KIND.INBOUND_STATS);
+  const selectedPair = entry.evidenceByKind.get(SWARM.MEDIA_FULFILLMENT_EVIDENCE_KIND.SELECTED_CANDIDATE_PAIR);
+  entry.blockedCategory = '';
+  entry.renderReadinessState = String(renderFacts.readinessState || latestFacts.readinessState || '').trim();
+  entry.selectedPairState = String(selectedPair?.safeFacts?.pairState || latestFacts.selectedPairState || '').trim();
+  entry.inboundRtpState = inbound?.state === SWARM.MEDIA_FULFILLMENT_STATE.BLOCKED
+    ? 'stalled'
+    : inbound?.state === SWARM.MEDIA_FULFILLMENT_STATE.USABLE
+      ? 'flowing'
+      : String(latestFacts.inboundRtpState || '').trim();
+  entry.renderState = render?.state === SWARM.MEDIA_FULFILLMENT_STATE.BLOCKED
+    ? 'blocked'
+    : render?.state === SWARM.MEDIA_FULFILLMENT_STATE.USABLE
+      ? 'visible'
+      : String(latestFacts.renderState || '').trim();
+  if (entry.state === SWARM.MEDIA_FULFILLMENT_STATE.RELEASED) return 'released';
+  if (entry.state === SWARM.MEDIA_FULFILLMENT_STATE.USABLE) return 'adapterLive';
+  if (entry.state === SWARM.MEDIA_FULFILLMENT_STATE.BLOCKED) {
+    const reason = entry.blockedReasons[0] || String(latestEvidence.blockedReason || '').trim();
+    const category = mediaBlockedCategory(reason, latestKind, latestFacts);
+    entry.blockedCategory = category;
+    if (category === 'render') return 'renderBlocked';
+    if (category === 'mediaPath') return 'mediaPathBlocked';
+    return 'mediaBlocked';
+  }
+  if (
+    entry.renderReadinessState === 'waitingRender'
+    || entry.renderReadinessState === 'pendingRender'
+    || entry.trackLive
+    || entry.transportUsable
+  ) {
+    return 'waitingRender';
+  }
+  return 'waitingMediaEvidence';
 }
 
 function streamRecoveryObject() {
@@ -8269,6 +8362,7 @@ function reduceMediaFulfillmentState(entry) {
   } else {
     entry.state = SWARM.MEDIA_FULFILLMENT_STATE.PENDING;
   }
+  entry.postureState = mediaRuntimePostureState(entry);
   return entry;
 }
 
@@ -8286,10 +8380,16 @@ function reduceMediaFulfillmentEvidence(record) {
     serviceRef: '',
     routePromiseId: '',
     state: SWARM.MEDIA_FULFILLMENT_STATE.PENDING,
+    postureState: 'waitingMediaEvidence',
+    blockedCategory: '',
     blockedReasons: [],
     visibleFrame: false,
     trackLive: false,
     transportUsable: false,
+    renderReadinessState: '',
+    selectedPairState: '',
+    inboundRtpState: '',
+    renderState: '',
     updatedAt: 0,
     expiresAt: 0,
     latestEvidence: null,
@@ -8345,15 +8445,26 @@ function applyMediaFulfillmentPostureToQueuedFrame(posture = {}) {
   const entry = findQueuedFrameForMediaFulfillmentPosture(posture);
   if (!entry) return false;
   const state = String(posture.state || '').trim();
+  const postureState = String(posture.postureState || '').trim();
   entry.mediaFulfillment = safeClone(posture);
   entry.mediaFulfillmentAt = Number(posture.updatedAt || 0) || nowMs();
   if (state === SWARM.MEDIA_FULFILLMENT_STATE.BLOCKED) {
-    entry.status = 'mediaBlocked';
+    entry.status = postureState || 'mediaBlocked';
+    const errorCode = postureState === 'renderBlocked'
+      ? 'media.renderBlocked'
+      : postureState === 'mediaPathBlocked'
+        ? 'media.pathBlocked'
+        : 'media.blocked';
     entry.lastError = {
-      code: 'media.blocked',
+      code: errorCode,
       message: posture.blockedReasons?.[0] || 'media transport blocked',
       retryable: true,
     };
+  } else if (state === SWARM.MEDIA_FULFILLMENT_STATE.PENDING && postureState === 'waitingRender') {
+    if (!queuedSwarmFrameTerminal(entry)) {
+      entry.status = 'waitingRender';
+      entry.lastError = undefined;
+    }
   } else if (state === SWARM.MEDIA_FULFILLMENT_STATE.USABLE) {
     if (!queuedSwarmFrameTerminal(entry)) {
       entry.status = 'adapterLive';
@@ -8370,6 +8481,7 @@ function applyMediaFulfillmentPostureToQueuedFrame(posture = {}) {
     routePromiseId: String(entry.routePromiseId || posture.routePromiseId || '').trim(),
     sessionId: String(posture.sessionId || '').trim(),
     state,
+    postureState,
     blockedReason: String(posture.blockedReasons?.[0] || '').trim(),
   });
   return true;

--- a/runtime.worker.js
+++ b/runtime.worker.js
@@ -1437,6 +1437,34 @@ function runtimeResourceSample() {
   };
 }
 
+function runtimeResourcePostureSummary() {
+  const sample = runtimeResourceSample();
+  const posture = normalizeObject(sample.posture);
+  const state = String(posture.state || RESOURCE_POSTURE_STATES.WITHIN_BUDGET).trim() || RESOURCE_POSTURE_STATES.WITHIN_BUDGET;
+  const reasons = normalizeArray(posture.reasons).map((entry) => String(entry || '').trim()).filter(Boolean);
+  return {
+    kind: 'runtime.resource.postureSummary',
+    state,
+    reason: reasons.join(', '),
+    profileId: String(sample.activeProfile?.id || 'balanced').trim() || 'balanced',
+    cleanupAllowed: false,
+    cleanupReason: 'retention posture must allow release before sweeping',
+    evidenceRefs: [`resource.sample:${sample.observedAt}`],
+    protocolRef: sample.protocol?.posture?.postureId || '',
+    sampledAt: sample.observedAt,
+  };
+}
+
+function runtimeRetentionPostureSummary() {
+  return {
+    kind: 'runtime.retention.postureSummary',
+    state: 'releaseRequired',
+    reason: 'local release requires explicit retention release posture',
+    releaseRequired: true,
+    destructiveAction: false,
+  };
+}
+
 function retentionRank(retentionClass) {
   const normalized = String(retentionClass || '').trim();
   const ranks = {
@@ -7706,6 +7734,8 @@ function runtimeSnapshot() {
     swarmQueue: swarmQueueObject(),
     activationResolutions: activationResolutionObject(),
     authority: safeClone(runtimeAuthorityPostureState),
+    resource: safeClone(runtimeResourcePostureSummary()),
+    retention: safeClone(runtimeRetentionPostureSummary()),
     diagnostics: diagnosticSnapshot(),
     runtimeEvents: runtimeEvents.slice(-RUNTIME_DIAGNOSTIC_SNAPSHOT_LIMIT).map((entry) => safeClone(entry)),
     mediaFulfillment: mediaFulfillmentObject(),

--- a/surface-app-contract.js
+++ b/surface-app-contract.js
@@ -1,5 +1,15 @@
 import { SURFACE_APP, assertSurfaceAppContract } from "../constitute-protocol/src/index.js";
 import { defineSurfaceAppContract } from "../constitute-ui/src/surface-app-contract.js";
+import { createRuntimeSurfaceClient } from "../constitute-ui/src/runtime-surface-client.js";
+import {
+  createSurfaceModuleRegistry,
+  surfaceAppModuleImplementations,
+} from "../constitute-ui/src/surface-module-registry.js";
+import {
+  browserStorageShellContext,
+  deriveRuntimeShellState,
+  runtimeShellConnectionToneClass,
+} from "./runtime-shell-state.js";
 
 const ISSUED_AT = 1700000000;
 
@@ -82,6 +92,60 @@ export const accountSurfaceAppContract = assertSurfaceAppContract({
 export const accountSurfaceApp = defineSurfaceAppContract(accountSurfaceAppContract, {
   validate: assertSurfaceAppContract,
 });
+
+export const accountSurfaceModuleRegistry = createSurfaceModuleRegistry([
+  {
+    moduleRef: "constitute-ui/runtime-surface-client@0.1.0",
+    role: SURFACE_APP.MODULE_ROLE.RUNTIME_CLIENT,
+    version: "0.1.0",
+    primitiveRefs: ["runtime.attach", "runtime.intent"],
+    implementation: Object.freeze({ createRuntimeSurfaceClient }),
+  },
+  {
+    moduleRef: "constitute-account/runtime-ui-model@0.1.0",
+    role: SURFACE_APP.MODULE_ROLE.PROJECTION_MODEL,
+    version: "0.1.0",
+    primitiveRefs: ["runtime.shell.posture", "projection.materialization"],
+    implementation: Object.freeze({
+      deriveRuntimeShellState,
+      runtimeShellConnectionToneClass,
+    }),
+  },
+  {
+    moduleRef: "constitute-account/browser-storage-shell@0.1.0",
+    role: SURFACE_APP.MODULE_ROLE.PLATFORM_ADAPTER,
+    version: "0.1.0",
+    primitiveRefs: ["runtime.shell.context"],
+    implementation: Object.freeze({ browserStorageShellContext }),
+  },
+  {
+    moduleRef: "constitute-account/account-view@0.1.0",
+    role: SURFACE_APP.MODULE_ROLE.PRODUCT_VIEW,
+    version: "0.1.0",
+    primitiveRefs: ["runtime.posture.render"],
+    implementation: Object.freeze({ surfaceRef: "constitute-account" }),
+  },
+]);
+
+export const accountSurfaceModules = surfaceAppModuleImplementations(
+  accountSurfaceModuleRegistry,
+  accountSurfaceApp,
+);
+
+export const accountRuntimeClientModule = accountSurfaceModuleRegistry.require(
+  accountSurfaceApp,
+  SURFACE_APP.MODULE_ROLE.RUNTIME_CLIENT,
+).implementation;
+
+export const accountProjectionModelModule = accountSurfaceModuleRegistry.require(
+  accountSurfaceApp,
+  SURFACE_APP.MODULE_ROLE.PROJECTION_MODEL,
+).implementation;
+
+export const accountPlatformAdapterModule = accountSurfaceModuleRegistry.require(
+  accountSurfaceApp,
+  SURFACE_APP.MODULE_ROLE.PLATFORM_ADAPTER,
+).implementation;
 
 export const accountSurfaceAttachContext = accountSurfaceApp.attachContext({
   productSurface: "constitute-account",


### PR DESCRIPTION
## Summary
- render account runtime, resource, retention, and media posture from shared reducers
- keep Account UI as a bundled surface app contract fulfillment
- resolve account runtime-client, projection-model, platform-adapter, and product-view modules through the app contract registry

## Tests
- npm test
- npm run build