### PR TITLE
Declare account service manager and materialization posture

### DIFF
--- a/app/runtime-shell-state.test.js
+++ b/app/runtime-shell-state.test.js
@@ -35,6 +35,16 @@ test("shell state derives online service posture from edge and retained projecti
       cleanupAllowed: false,
       cleanupReason: "retention posture must allow release before sweeping",
     },
+    materialization: {
+      state: "withinBudget",
+      budgets: [
+        { budgetId: "runtime.projections.retained" },
+        { budgetId: "runtime.events.ring" },
+      ],
+      fanout: 1,
+      projectionCount: 1,
+      runtimeEventCount: 4,
+    },
     retention: {
       state: "releaseRequired",
       reason: "local release requires explicit retention release posture",
@@ -60,6 +70,9 @@ test("shell state derives online service posture from edge and retained projecti
   assert.equal(state.projections.materialized, true);
   assert.equal(state.resource.state, "withinBudget");
   assert.equal(state.resource.cleanupAllowed, false);
+  assert.equal(state.materialization.state, "withinBudget");
+  assert.equal(state.materialization.budgetCount, 2);
+  assert.equal(state.materialization.runtimeEventCount, 4);
   assert.equal(state.retention.state, "releaseRequired");
   assert.equal(state.retention.releaseRequired, true);
 });

--- a/app/runtime-swarm-edge.test.js
+++ b/app/runtime-swarm-edge.test.js
@@ -654,6 +654,11 @@ test('runtime attach declares snapshot materialization budget per surface', asyn
     entry.budgetId === attached.materializationBudget.budgetId
       && entry.clientId === 'surface-materialization-test'
   )), true);
+  assert.equal(snapshot.result.materialization.kind, 'runtime.materialization.summary');
+  assert.equal(snapshot.result.materialization.state, 'withinBudget');
+  assert.equal(snapshot.result.materialization.budgets.some((entry) => entry.budgetId === 'runtime.projections.retained'), true);
+  assert.equal(snapshot.result.materialization.budgets.some((entry) => entry.budgetId === 'runtime.events.ring'), true);
+  assert.equal(snapshot.result.productShellState.materialization.state, 'withinBudget');
   assert.equal(snapshot.result.resource.kind, 'runtime.resource.postureSummary');
   assert.equal(snapshot.result.resource.cleanupAllowed, false);
   assert.equal(snapshot.result.retention.kind, 'runtime.retention.postureSummary');

--- a/app/surface-app-contract.test.js
+++ b/app/surface-app-contract.test.js
@@ -2,8 +2,11 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import {
   accountRuntimeClientModule,
+  accountServiceManagerOperationPosture,
+  accountServiceManagerProofDigest,
   accountSurfaceApp,
   accountSurfaceAttachContext,
+  accountSurfaceBootstrapPosture,
   accountSurfaceModuleRegistry,
   accountSurfaceModules,
 } from "../surface-app-contract.js";
@@ -20,4 +23,9 @@ test("account ui declares its surface app modules before runtime attach", () => 
   assert.equal(accountSurfaceAttachContext.kind, "surface.app.attachContext");
   assert.equal(accountSurfaceAttachContext.appId, "constitute-account");
   assert.equal(accountSurfaceAttachContext.moduleRefs.length, 4);
+  assert.equal(accountSurfaceBootstrapPosture.state, "ready");
+  assert.equal(accountServiceManagerOperationPosture.kind, "service.manager.operation.posture");
+  assert.equal(accountServiceManagerOperationPosture.state, "requested");
+  assert.equal(accountServiceManagerProofDigest.kind, "service.manager.proof.digest");
+  assert.equal(accountSurfaceAttachContext.serviceManagerOperationPosture, accountServiceManagerOperationPosture);
 });

--- a/runtime-shell-state.js
+++ b/runtime-shell-state.js
@@ -201,6 +201,7 @@ export function deriveRuntimeShellState(snapshot = {}, options = {}) {
   const authority = record(snap.authority);
   const resource = record(snap.resource);
   const retention = record(snap.retention);
+  const materialization = record(snap.materialization);
 
   const identityId = firstText(
     identity.identityId,
@@ -359,6 +360,14 @@ export function deriveRuntimeShellState(snapshot = {}, options = {}) {
       profileId: firstText(resource.profileId),
       cleanupAllowed: resource.cleanupAllowed === true,
       cleanupReason: firstText(resource.cleanupReason),
+    }),
+    materialization: Object.freeze({
+      state: firstText(materialization.state, "unknown"),
+      reason: firstText(materialization.reason),
+      budgetCount: Array.isArray(materialization.budgets) ? materialization.budgets.length : 0,
+      fanout: Number(materialization.fanout || 0) || 0,
+      projectionCount: Number(materialization.projectionCount || 0) || 0,
+      runtimeEventCount: Number(materialization.runtimeEventCount || 0) || 0,
     }),
     retention: Object.freeze({
       state: firstText(retention.state, "unknown"),

--- a/runtime.worker.js
+++ b/runtime.worker.js
@@ -752,6 +752,219 @@ function diagnosticMaterializationSnapshot() {
   return summaries;
 }
 
+function materializationStateRank(state) {
+  const normalized = String(state || '').trim();
+  const ranks = {
+    [SWARM.RESOURCE_POSTURE_STATE.WITHIN_BUDGET]: 0,
+    [SWARM.RESOURCE_POSTURE_STATE.PRESSURE]: 1,
+    [SWARM.RESOURCE_POSTURE_STATE.OVER_BUDGET]: 2,
+    [SWARM.RESOURCE_POSTURE_STATE.SWEEPING]: 2,
+    [SWARM.RESOURCE_POSTURE_STATE.BLOCKED]: 3,
+    [SWARM.RESOURCE_POSTURE_STATE.UNAVAILABLE]: 3,
+  };
+  return Object.prototype.hasOwnProperty.call(ranks, normalized) ? ranks[normalized] : 3;
+}
+
+function materializationWorstState(budgets) {
+  let state = SWARM.RESOURCE_POSTURE_STATE.WITHIN_BUDGET;
+  for (const budget of normalizeArray(budgets)) {
+    const nextState = String(budget?.state || SWARM.RESOURCE_POSTURE_STATE.WITHIN_BUDGET).trim();
+    if (materializationStateRank(nextState) > materializationStateRank(state)) state = nextState;
+  }
+  return state;
+}
+
+function materializationBudgetSummary(budget) {
+  if (!budget) return null;
+  return {
+    budgetId: String(budget.budgetId || '').trim(),
+    consumerRef: String(budget.consumerRef || '').trim(),
+    payloadClass: String(budget.payloadClass || '').trim(),
+    copyRole: String(budget.copyRole || '').trim(),
+    transferMode: String(budget.transferMode || '').trim(),
+    privacyTier: String(budget.privacyTier || '').trim(),
+    state: String(budget.state || SWARM.RESOURCE_POSTURE_STATE.WITHIN_BUDGET).trim(),
+    blockedReasons: normalizeArray(budget.blockedReasons).map((entry) => String(entry || '').trim()).filter(Boolean),
+    retentionClass: String(budget.retentionClass || '').trim(),
+    referenceRefs: normalizeArray(budget.referenceRefs).map((entry) => String(entry || '').trim()).filter(Boolean),
+    consumerFloor: budget.consumerFloor ? {
+      floorId: String(budget.consumerFloor.floorId || '').trim(),
+      lagState: String(budget.consumerFloor.lagState || '').trim(),
+      ackFloor: String(budget.consumerFloor.ackFloor || '').trim(),
+      witnessFloor: String(budget.consumerFloor.witnessFloor || '').trim(),
+      compactionFloor: String(budget.consumerFloor.compactionFloor || '').trim(),
+    } : null,
+  };
+}
+
+function runtimeProjectionStoreConsumerFloor(sampledAt = nowMs()) {
+  const materializationId = 'runtime.projections.retained';
+  const currentRevision = Array.from(retainedProjections.values()).reduce((max, projection) => {
+    const coverage = projectionCoverage(projection);
+    return Math.max(max, Number(coverage.revision || 0) || 0);
+  }, 0);
+  const cursor = String(currentRevision || retainedProjections.size);
+  return assertConsumerFloor({
+    kind: SWARM.RECORD_KIND.CONSUMER_FLOOR,
+    floorId: `floor:${materializationId}`,
+    consumerRef: 'runtime.read-model',
+    materializationId,
+    subjectRef: 'runtime.projections',
+    lagState: SWARM.MATERIALIZATION_LAG_STATE.CAUGHT_UP,
+    cursor,
+    ackFloor: cursor,
+    witnessFloor: cursor,
+    compactionFloor: cursor,
+    eventTimeFloor: sampledAt,
+    observedTimeFloor: sampledAt,
+    replay: { mode: 'projection-store', projectionCount: retainedProjections.size },
+    redelivery: { mode: 'snapshot-repair', duplicatePolicy: 'projectionKey' },
+    sampledAt,
+    expiresAt: sampledAt + 60_000,
+  });
+}
+
+function runtimeProjectionStoreMaterializationBudget(sampledAt = nowMs()) {
+  const profile = runtimeResourceProfile();
+  const projectionLimit = Math.max(1, Number(profile?.caps?.projections || 256) || 256);
+  const projectionCountValue = retainedProjections.size;
+  const state = projectionCountValue > projectionLimit
+    ? SWARM.RESOURCE_POSTURE_STATE.OVER_BUDGET
+    : projectionCountValue >= projectionLimit * 0.8
+      ? SWARM.RESOURCE_POSTURE_STATE.PRESSURE
+      : SWARM.RESOURCE_POSTURE_STATE.WITHIN_BUDGET;
+  const blockedReasons = state === SWARM.RESOURCE_POSTURE_STATE.WITHIN_BUDGET
+    ? []
+    : ['projectionStoreMaterializationPressure'];
+  return assertMaterializationBudget({
+    kind: SWARM.RECORD_KIND.MATERIALIZATION_BUDGET,
+    budgetId: 'runtime.projections.retained',
+    sourceAuthority: `runtime:${runtimeSessionId}`,
+    consumerRef: 'runtime.read-model',
+    payloadClass: SWARM.MATERIALIZATION_PAYLOAD_CLASS.PROJECTION,
+    copyRole: SWARM.MATERIALIZATION_COPY_ROLE.CACHE,
+    transferMode: SWARM.MATERIALIZATION_TRANSFER_MODE.REFERENCE_ONLY,
+    privacyTier: SWARM.MATERIALIZATION_PRIVACY_TIER.SAFE_PROJECTION,
+    state,
+    limits: {
+      projectionCount: projectionCountValue,
+      projectionPolicyCount: projectionPolicies.size,
+      maxProjectionCount: projectionLimit,
+    },
+    snapshotPolicy: { mode: 'retained-projection-store' },
+    deltaPolicy: { mode: 'projection-delta-apply' },
+    coalescing: { key: 'projectionKey', duplicatePolicy: 'replaceLatest' },
+    cardinality: {
+      maxProjectionCount: projectionLimit,
+      keySpace: 'projectionId|channelId|scope',
+    },
+    schema: {
+      state: SWARM.MATERIALIZATION_SCHEMA_STATE.CURRENT,
+      version: 'runtime.projections.retained.v1',
+    },
+    consumerFloor: runtimeProjectionStoreConsumerFloor(sampledAt),
+    referenceRefs: ['runtime.projections.retained'],
+    blockedReasons,
+    retentionClass: 'ephemeral.runtime-projection-cache',
+    issuedAt: sampledAt,
+    releaseAfter: sampledAt + 60_000,
+    expiresAt: sampledAt + 5 * 60_000,
+  });
+}
+
+function runtimeEventRingConsumerFloor(sampledAt = nowMs()) {
+  const materializationId = 'runtime.events.ring';
+  const last = runtimeEvents[runtimeEvents.length - 1] || null;
+  const cursor = String(last?.eventId || runtimeEvents.length);
+  return assertConsumerFloor({
+    kind: SWARM.RECORD_KIND.CONSUMER_FLOOR,
+    floorId: `floor:${materializationId}`,
+    consumerRef: 'runtime.diagnostics.read-model',
+    materializationId,
+    subjectRef: RUNTIME_DIAGNOSTICS_CHANNEL,
+    lagState: SWARM.MATERIALIZATION_LAG_STATE.CAUGHT_UP,
+    cursor,
+    ackFloor: String(runtimeEvents.length),
+    witnessFloor: String(runtimeEvents.length),
+    compactionFloor: String(Math.max(0, runtimeEvents.length - RUNTIME_DIAGNOSTIC_SNAPSHOT_LIMIT)),
+    eventTimeFloor: Number(last?.observedAt || 0) || sampledAt,
+    observedTimeFloor: sampledAt,
+    replay: { mode: SWARM.EVENT_DELIVERY_MODE.REPLAY, replayLimit: RUNTIME_DIAGNOSTIC_SNAPSHOT_LIMIT },
+    redelivery: { mode: 'ring-snapshot', duplicatePolicy: 'eventId' },
+    sampledAt,
+    expiresAt: sampledAt + 60_000,
+  });
+}
+
+function runtimeEventRingMaterializationBudget(sampledAt = nowMs()) {
+  const state = runtimeEvents.length >= RUNTIME_DIAGNOSTIC_RING_LIMIT
+    ? SWARM.RESOURCE_POSTURE_STATE.PRESSURE
+    : SWARM.RESOURCE_POSTURE_STATE.WITHIN_BUDGET;
+  return assertMaterializationBudget({
+    kind: SWARM.RECORD_KIND.MATERIALIZATION_BUDGET,
+    budgetId: 'runtime.events.ring',
+    sourceAuthority: `runtime:${runtimeSessionId}`,
+    consumerRef: 'runtime.diagnostics.read-model',
+    payloadClass: SWARM.MATERIALIZATION_PAYLOAD_CLASS.EVIDENCE,
+    copyRole: SWARM.MATERIALIZATION_COPY_ROLE.BUFFER,
+    transferMode: SWARM.MATERIALIZATION_TRANSFER_MODE.CLONE,
+    privacyTier: SWARM.MATERIALIZATION_PRIVACY_TIER.SAFE_FACTS,
+    state,
+    limits: {
+      eventCount: runtimeEvents.length,
+      snapshotEventCount: Math.min(runtimeEvents.length, RUNTIME_DIAGNOSTIC_SNAPSHOT_LIMIT),
+      ringLimit: RUNTIME_DIAGNOSTIC_RING_LIMIT,
+    },
+    snapshotPolicy: { mode: 'bounded-ring-tail' },
+    deltaPolicy: { mode: 'append-only-coalesced' },
+    coalescing: { key: 'eventId' },
+    cardinality: {
+      maxEventCount: RUNTIME_DIAGNOSTIC_RING_LIMIT,
+      highCardinalityOverflow: 'dropOldest',
+    },
+    schema: {
+      state: SWARM.MATERIALIZATION_SCHEMA_STATE.CURRENT,
+      version: 'runtime.events.ring.v1',
+    },
+    consumerFloor: runtimeEventRingConsumerFloor(sampledAt),
+    blockedReasons: state === SWARM.RESOURCE_POSTURE_STATE.WITHIN_BUDGET ? [] : ['runtimeEventRingPressure'],
+    retentionClass: 'ephemeral.runtime-diagnostics',
+    issuedAt: sampledAt,
+    releaseAfter: sampledAt + 60_000,
+    expiresAt: sampledAt + 5 * 60_000,
+  });
+}
+
+function runtimeMaterializationSummary(sampledAt = nowMs()) {
+  const budgets = [
+    runtimeProjectionStoreMaterializationBudget(sampledAt),
+    runtimeEventRingMaterializationBudget(sampledAt),
+    diagnosticLoggingBacklogMaterializationBudget(sampledAt),
+    ...Array.from(endpoints.values())
+      .map((endpoint) => endpoint?.runtimeSnapshotMaterializationBudget)
+      .filter(Boolean),
+  ];
+  const state = materializationWorstState(budgets);
+  const budgetSummaries = budgets.map((budget) => materializationBudgetSummary(budget)).filter(Boolean);
+  return {
+    kind: 'runtime.materialization.summary',
+    state,
+    reason: state === SWARM.RESOURCE_POSTURE_STATE.WITHIN_BUDGET
+      ? ''
+      : budgetSummaries
+        .flatMap((budget) => budget.blockedReasons)
+        .filter(Boolean)
+        .join(', '),
+    budgets: budgetSummaries,
+    fanout: endpoints.size,
+    projectionCount: retainedProjections.size,
+    projectionPolicyCount: projectionPolicies.size,
+    runtimeEventCount: runtimeEvents.length,
+    diagnosticLoggingBacklogCount: diagnosticLoggingBacklog.length,
+    sampledAt,
+  };
+}
+
 function runtimeSnapshotConsumerFloor(endpoint, sampledAt = nowMs()) {
   const clientId = String(endpoint?.clientId || 'runtime-surface').trim() || 'runtime-surface';
   const materializationId = `materialization:${clientId}:runtime-snapshot`;
@@ -7736,6 +7949,7 @@ function runtimeSnapshot() {
     authority: safeClone(runtimeAuthorityPostureState),
     resource: safeClone(runtimeResourcePostureSummary()),
     retention: safeClone(runtimeRetentionPostureSummary()),
+    materialization: safeClone(runtimeMaterializationSummary()),
     diagnostics: diagnosticSnapshot(),
     runtimeEvents: runtimeEvents.slice(-RUNTIME_DIAGNOSTIC_SNAPSHOT_LIMIT).map((entry) => safeClone(entry)),
     mediaFulfillment: mediaFulfillmentObject(),

--- a/surface-app-contract.js
+++ b/surface-app-contract.js
@@ -1,5 +1,10 @@
 import { SURFACE_APP, assertSurfaceAppContract } from "../constitute-protocol/src/index.js";
-import { defineSurfaceAppContract } from "../constitute-ui/src/surface-app-contract.js";
+import {
+  defineSurfaceAppContract,
+  surfaceAppBootstrapPosture,
+  surfaceServiceManagerOperationPosture,
+  surfaceServiceManagerProofDigest,
+} from "../constitute-ui/src/surface-app-contract.js";
 import { createRuntimeSurfaceClient } from "../constitute-ui/src/runtime-surface-client.js";
 import {
   createSurfaceModuleRegistry,
@@ -86,6 +91,23 @@ export const accountSurfaceAppContract = assertSurfaceAppContract({
     state: SURFACE_APP.UPDATE_POSTURE.STATIC,
     checkedAt: ISSUED_AT,
   },
+  serviceManagerPosture: {
+    managerId: "manager:manual:account-ui",
+    subjectRef: "app:account-ui",
+    managerRef: "manager:manual:account-ui",
+    state: SURFACE_APP.SERVICE_MANAGER_POSTURE.MANUAL,
+    serviceRefs: ["app:account-ui"],
+    capabilityRefs: ["service.manage"],
+    evidenceRefs: ["build:account-ui:local"],
+    issuedAt: ISSUED_AT,
+  },
+  secretBoundary: {
+    state: SURFACE_APP.SECRET_BOUNDARY.NOT_REQUIRED,
+  },
+  releasePosture: {
+    state: SURFACE_APP.RELEASE_POSTURE.STATIC,
+    evidenceRefs: ["build:account-ui:local"],
+  },
   issuedAt: ISSUED_AT,
 });
 
@@ -132,6 +154,22 @@ export const accountSurfaceModules = surfaceAppModuleImplementations(
   accountSurfaceApp,
 );
 
+export const accountSurfaceBootstrapPosture = surfaceAppBootstrapPosture(accountSurfaceApp, {
+  issuedAt: ISSUED_AT,
+});
+
+export const accountServiceManagerOperationPosture = surfaceServiceManagerOperationPosture(accountSurfaceApp, {
+  operation: SURFACE_APP.SERVICE_MANAGER_OPERATION.HEALTH_CHECK,
+  operationId: "operation:account-ui:bootstrap-health",
+  requestedAt: ISSUED_AT,
+});
+
+export const accountServiceManagerProofDigest = surfaceServiceManagerProofDigest(accountSurfaceApp, {
+  operationPosture: accountServiceManagerOperationPosture,
+  digestId: "proof-digest:account-ui:bootstrap",
+  observedAt: ISSUED_AT,
+});
+
 export const accountRuntimeClientModule = accountSurfaceModuleRegistry.require(
   accountSurfaceApp,
   SURFACE_APP.MODULE_ROLE.RUNTIME_CLIENT,
@@ -149,4 +187,7 @@ export const accountPlatformAdapterModule = accountSurfaceModuleRegistry.require
 
 export const accountSurfaceAttachContext = accountSurfaceApp.attachContext({
   productSurface: "constitute-account",
+  bootstrapPosture: accountSurfaceBootstrapPosture,
+  serviceManagerOperationPosture: accountServiceManagerOperationPosture,
+  serviceManagerProofDigest: accountServiceManagerProofDigest,
 });


### PR DESCRIPTION
## Summary
- Declare Account as a surface app contract participant.
- Add runtime-owned materialization posture for projection, diagnostics, endpoint, and snapshot budgets.

## Checks
- constitute-account tests/build passed locally.
- Root browser smoke passed.
- Root check:all passed locally.