### PR TITLE
Converge runtime activation posture

### DIFF
--- a/app.js
+++ b/app.js
@@ -664,8 +664,8 @@ function bootFromRuntimeSnapshot() {
     return null;
   }
   runtimeBridge.whenReady(SHELL_BOOT_RUNTIME_ATTACH_TIMEOUT_MS)
-    .then(() => {
-      markShellBoot('shell.runtime-attached');
+    .then((snapshot) => {
+      markShellBoot(snapshot ? 'shell.runtime-attached' : 'shell.runtime-attach.unavailable');
     })
     .catch((err) => {
       if (!runtimeAttachWarningLogged) {
@@ -2121,22 +2121,31 @@ function startPlatformRuntimeBridge() {
       bridge.rejectReady = null;
       bridge.resolveReady = null;
     },
+    onAttachPosture: (posture) => {
+      if (!posture || posture.severity === 'info') return;
+      if (!runtimeAttachWarningLogged) {
+        runtimeAttachWarningLogged = true;
+        console.info('[runtime] SharedWorker attach fallback', {
+          state: posture.state,
+          severity: posture.severity,
+          reason: posture.reason,
+        });
+      }
+    },
     onAttachError: (err) => {
       bridge.attachTimedOut = true;
       bridge.attachError = err;
-      bridge.rejectReady?.(err);
-      bridge.rejectReady = null;
+      bridge.resolveReady?.(null);
       bridge.resolveReady = null;
-      console.error('[runtime] SharedWorker attach failed', err);
+      bridge.rejectReady = null;
     },
     onWorkerError: (event) => {
       const error = new Error(String(event?.message || 'shared worker failure'));
       bridge.attachTimedOut = true;
       bridge.attachError = error;
-      bridge.rejectReady?.(error);
-      bridge.rejectReady = null;
+      bridge.resolveReady?.(null);
       bridge.resolveReady = null;
-      console.error('[runtime] SharedWorker error', event?.message || event);
+      bridge.rejectReady = null;
     },
   });
   bridge.client = runtimeClient;

--- a/app/runtime-swarm-edge.test.js
+++ b/app/runtime-swarm-edge.test.js
@@ -2387,6 +2387,34 @@ test('live swarm edge attach requires resolved member refs and reuses duplicate 
   assert.equal(closedEvent?.safeFacts?.closeCode, 1006);
 });
 
+test('live swarm edge attach waits for runtime authority when member ref is runtime-owned', async () => {
+  const runtime = loadRuntime(new Map(), { noDevice: true });
+  await attach(runtime.port);
+  const zoneScope = { zoneId: 'zone_lab', privacy: 'rawIds', ttl: 30, maxHops: 2 };
+
+  const blocked = await send(runtime.port, {
+    type: 'swarm.edge.attach',
+    payload: {
+      swarmEdgeEndpoint: 'ws://127.0.0.1:7447/',
+      zoneScope,
+    },
+  });
+
+  assert.equal(blocked.ok, false);
+  assert.match(blocked.error, /missingRuntimeAuthorityMemberRef/);
+  assert.equal(blocked.state, 'waitingAuthority');
+  assert.equal(blocked.blockedReason, 'missingRuntimeAuthorityMemberRef');
+  assert.equal(runtime.webSockets.length, 0);
+
+  const snapshot = await send(runtime.port, { type: 'runtime.snapshot.get' });
+  assert.equal(snapshot.result.edge.mode, 'pendingAuthority');
+  assert.equal(snapshot.result.edge.connected, false);
+  const blockedEvent = snapshot.result.runtimeEvents.find((entry) => entry.kind === 'adapter.edge.attach.blocked');
+  assert.equal(blockedEvent?.safeFacts?.blockedReason, 'missingRuntimeAuthorityMemberRef');
+  assert.equal(blockedEvent?.safeFacts?.retryable, true);
+  assert.equal(blockedEvent?.level, 'info');
+});
+
 test('live swarm edge attach is not gated by runtime hydration', () => {
   const source = readFileSync(workerPath, 'utf8');
   assert.doesNotMatch(

--- a/app/runtime-swarm-edge.test.js
+++ b/app/runtime-swarm-edge.test.js
@@ -479,9 +479,8 @@ test('expired activations ignore late acks instead of re-opening route churn', a
   assert.equal(subscribed.ok, true);
   const queued = await send(runtime.port, {
     type: 'swarm.frame.queue',
-    payload: frameInput({ expiresAt: Date.now() + 50 }),
+    payload: frameInput({ expiresAt: Date.now() - 1 }),
   });
-  await new Promise((resolve) => setTimeout(resolve, 70));
 
   const ack = await send(runtime.port, { type: 'swarm.edge.ack', correlationId: queued.result.frameId });
   assert.equal(ack.ok, true);

--- a/app/surface-app-contract.test.js
+++ b/app/surface-app-contract.test.js
@@ -15,6 +15,7 @@ import {
   accountSurfaceModules,
   accountSurfaceRuntimeSelectionPosture,
   accountSurfaceRunnerPlan,
+  accountSurfaceSelectionReadModel,
 } from "../surface-app-contract.js";
 
 test("account ui declares its surface app modules before runtime attach", () => {
@@ -25,6 +26,8 @@ test("account ui declares its surface app modules before runtime attach", () => 
   assert.equal(accountSurfaceApp.hasRole("productView"), true);
   assert.equal(accountSurfaceModuleRegistry.kind, "surface.module.registry");
   assert.equal(accountSurfaceModules.state, "ready");
+  assert.equal(accountSurfaceSelectionReadModel.kind, "surface.app.selection.readModel");
+  assert.equal(accountSurfaceSelectionReadModel.state, "ready");
   assert.equal(typeof accountRuntimeClientModule.createRuntimeSurfaceClient, "function");
   assert.equal(accountSurfaceAttachContext.kind, "surface.app.attachContext");
   assert.equal(accountSurfaceAttachContext.appId, "constitute-account");
@@ -49,6 +52,7 @@ test("account ui declares its surface app modules before runtime attach", () => 
   assert.equal(accountSurfaceAttachContext.runnerPlan, accountSurfaceRunnerPlan);
   assert.equal(accountSurfaceAttachContext.appInstancePosture, accountSurfaceAppInstancePosture);
   assert.equal(accountSurfaceAttachContext.runtimeSelectionPosture, accountSurfaceRuntimeSelectionPosture);
+  assert.equal(accountSurfaceSelectionReadModel.attachContext, accountSurfaceAttachContext);
   assert.equal(accountSurfaceAttachContext.bootstrapContract, accountSurfaceBootstrapContract);
   assert.equal(accountSurfaceAttachContext.serviceManagerOperationPosture, accountServiceManagerOperationPosture);
 });

--- a/app/surface-app-contract.test.js
+++ b/app/surface-app-contract.test.js
@@ -6,6 +6,7 @@ import {
   accountServiceManagerProofDigest,
   accountServiceManagerSecretBoundary,
   accountSurfaceApp,
+  accountSurfaceAppInstancePosture,
   accountSurfaceAttachContext,
   accountSurfaceAppManifest,
   accountSurfaceBootstrapContract,
@@ -27,6 +28,9 @@ test("account ui declares its surface app modules before runtime attach", () => 
   assert.equal(typeof accountRuntimeClientModule.createRuntimeSurfaceClient, "function");
   assert.equal(accountSurfaceAttachContext.kind, "surface.app.attachContext");
   assert.equal(accountSurfaceAttachContext.appId, "constitute-account");
+  assert.equal(accountSurfaceAppInstancePosture.kind, "surface.app.instance.posture");
+  assert.equal(accountSurfaceAppInstancePosture.state, "ready");
+  assert.equal(accountSurfaceAppInstancePosture.appId, "constitute-account");
   assert.equal(accountSurfaceAppManifest.kind, "surface.app.manifest");
   assert.equal(accountSurfaceRuntimeSelectionPosture.kind, "surface.app.runtime.selection.posture");
   assert.equal(accountSurfaceRuntimeSelectionPosture.state, "ready");
@@ -43,6 +47,7 @@ test("account ui declares its surface app modules before runtime attach", () => 
   assert.equal(accountServiceManagerOperationPosture.state, "requested");
   assert.equal(accountServiceManagerProofDigest.kind, "service.manager.proof.digest");
   assert.equal(accountSurfaceAttachContext.runnerPlan, accountSurfaceRunnerPlan);
+  assert.equal(accountSurfaceAttachContext.appInstancePosture, accountSurfaceAppInstancePosture);
   assert.equal(accountSurfaceAttachContext.runtimeSelectionPosture, accountSurfaceRuntimeSelectionPosture);
   assert.equal(accountSurfaceAttachContext.bootstrapContract, accountSurfaceBootstrapContract);
   assert.equal(accountSurfaceAttachContext.serviceManagerOperationPosture, accountServiceManagerOperationPosture);

--- a/app/surface-app-contract.test.js
+++ b/app/surface-app-contract.test.js
@@ -7,10 +7,12 @@ import {
   accountServiceManagerSecretBoundary,
   accountSurfaceApp,
   accountSurfaceAttachContext,
+  accountSurfaceAppManifest,
   accountSurfaceBootstrapContract,
   accountSurfaceBootstrapPosture,
   accountSurfaceModuleRegistry,
   accountSurfaceModules,
+  accountSurfaceRuntimeSelectionPosture,
   accountSurfaceRunnerPlan,
 } from "../surface-app-contract.js";
 
@@ -25,6 +27,10 @@ test("account ui declares its surface app modules before runtime attach", () => 
   assert.equal(typeof accountRuntimeClientModule.createRuntimeSurfaceClient, "function");
   assert.equal(accountSurfaceAttachContext.kind, "surface.app.attachContext");
   assert.equal(accountSurfaceAttachContext.appId, "constitute-account");
+  assert.equal(accountSurfaceAppManifest.kind, "surface.app.manifest");
+  assert.equal(accountSurfaceRuntimeSelectionPosture.kind, "surface.app.runtime.selection.posture");
+  assert.equal(accountSurfaceRuntimeSelectionPosture.state, "ready");
+  assert.equal(accountSurfaceRuntimeSelectionPosture.pinnedAppContractRef, "app:account-ui");
   assert.equal(accountSurfaceAttachContext.moduleRefs.length, 4);
   assert.equal(accountSurfaceBootstrapPosture.state, "ready");
   assert.equal(accountSurfaceRunnerPlan.kind, "surface.app.runner.plan");
@@ -37,6 +43,7 @@ test("account ui declares its surface app modules before runtime attach", () => 
   assert.equal(accountServiceManagerOperationPosture.state, "requested");
   assert.equal(accountServiceManagerProofDigest.kind, "service.manager.proof.digest");
   assert.equal(accountSurfaceAttachContext.runnerPlan, accountSurfaceRunnerPlan);
+  assert.equal(accountSurfaceAttachContext.runtimeSelectionPosture, accountSurfaceRuntimeSelectionPosture);
   assert.equal(accountSurfaceAttachContext.bootstrapContract, accountSurfaceBootstrapContract);
   assert.equal(accountSurfaceAttachContext.serviceManagerOperationPosture, accountServiceManagerOperationPosture);
 });

--- a/runtime.worker.js
+++ b/runtime.worker.js
@@ -4803,6 +4803,16 @@ function resolvedRuntimeAuthorityMemberRef() {
   );
 }
 
+function isMissingImplicitEdgeMemberRef(source) {
+  return !String(source?.memberRef || '').trim();
+}
+
+function edgeAttachWaitingAuthorityMessage() {
+  const state = String(runtimeAuthorityPostureState?.state || 'waitingAuthority').trim() || 'waitingAuthority';
+  const reason = String(runtimeAuthorityPostureState?.reason || 'runtime authority memberRef is not ready').trim();
+  return `runtime authority ${state}: missingRuntimeAuthorityMemberRef${reason ? ` (${reason})` : ''}`;
+}
+
 function resolvedEdgeMemberRefFromMessage(source) {
   const memberRef = String(source?.memberRef || '').trim();
   if (!memberRef) {
@@ -5078,15 +5088,51 @@ async function attachLiveSwarmEdge(message) {
     return { ok: false, error: 'WebSocket unavailable in runtime worker' };
   }
   markRuntimeControlPlaneBusy(15_000);
+  if (isMissingImplicitEdgeMemberRef(source)) {
+    await runtimeAuthorityPosture().catch(() => null);
+  }
   let memberRef = '';
   try {
     memberRef = resolvedEdgeMemberRefFromMessage(source);
   } catch (error) {
+    const waitingAuthority = isMissingImplicitEdgeMemberRef(source);
+    const message = waitingAuthority
+      ? edgeAttachWaitingAuthorityMessage()
+      : String(error?.message || error || 'resolved swarm edge memberRef is required');
+    if (waitingAuthority) {
+      const requestedZoneScope = appIntentZoneScope(source);
+      closeSwarmEdgeSocket();
+      swarmEdge.mode = 'pendingAuthority';
+      swarmEdge.connected = false;
+      swarmEdge.endpoint = socketEndpoint;
+      swarmEdge.sessionId = '';
+      swarmEdge.memberRef = '';
+      swarmEdge.zoneScope = safeClone(requestedZoneScope);
+      recordRuntimeEvent('adapter.edge.attach.blocked', {
+        level: 'info',
+        state: String(runtimeAuthorityPostureState?.state || 'waitingAuthority').trim() || 'waitingAuthority',
+        blockedReason: 'missingRuntimeAuthorityMemberRef',
+        retryable: true,
+        error: { message },
+        ...edgeEndpointDiagnosticFacts(socketEndpoint),
+        zoneScope: requestedZoneScope,
+      });
+      touchRuntime();
+      broadcastSnapshot();
+      return {
+        ok: false,
+        error: message,
+        state: 'waitingAuthority',
+        blockedReason: 'missingRuntimeAuthorityMemberRef',
+        retryable: true,
+        result: edgeSnapshot(),
+      };
+    }
     recordRuntimeEvent('adapter.edge.attach.failed', {
-      error: { message: String(error?.message || error || 'resolved swarm edge memberRef is required') },
+      error: { message },
       level: 'error',
     });
-    return { ok: false, error: String(error?.message || error || 'resolved swarm edge memberRef is required') };
+    return { ok: false, error: message };
   }
   const requestedZoneScope = appIntentZoneScope(source);
   const attachTarget = `${socketEndpoint}|${memberRef}|${stableJson(requestedZoneScope)}`;
@@ -9174,6 +9220,7 @@ async function hydrateRuntimeState() {
     }
     for (const timer of serviceAdmissionTimeoutTimers.values()) self.clearTimeout(timer);
     serviceAdmissionTimeoutTimers.clear();
+    const liveSwarmQueue = new Map(outboundSwarmFrames);
     outboundSwarmFrames.clear();
     if (sameRuntimeBuild) {
       const persistedSwarmQueue = payload.swarmQueue && typeof payload.swarmQueue === 'object'
@@ -9201,9 +9248,12 @@ async function hydrateRuntimeState() {
           });
         } catch {}
       }
-      for (const entry of outboundSwarmFrames.values()) {
-        scheduleServiceAdmissionTimeout(entry);
-      }
+    }
+    for (const [frameId, entry] of liveSwarmQueue.entries()) {
+      outboundSwarmFrames.set(frameId, entry);
+    }
+    for (const entry of outboundSwarmFrames.values()) {
+      scheduleServiceAdmissionTimeout(entry);
     }
     mediaFulfillmentPostures.clear();
     const persistedMediaFulfillment = payload.mediaFulfillment && typeof payload.mediaFulfillment === 'object'

--- a/surface-app-contract.js
+++ b/surface-app-contract.js
@@ -227,7 +227,7 @@ export const accountSurfaceModuleRegistry = createSurfaceModuleRegistry([
 
 export const accountSurfaceModules = surfaceAppModuleImplementations(
   accountSurfaceModuleRegistry,
-  accountSurfaceApp,
+  accountSurfaceRuntimeSelectionPosture,
 );
 
 export const accountSurfaceRunnerPlan = surfaceAppRunnerPlan(accountSurfaceApp, {
@@ -259,17 +259,17 @@ export const accountServiceManagerProofDigest = surfaceServiceManagerProofDigest
 });
 
 export const accountRuntimeClientModule = accountSurfaceModuleRegistry.require(
-  accountSurfaceApp,
+  accountSurfaceRuntimeSelectionPosture,
   SURFACE_APP.MODULE_ROLE.RUNTIME_CLIENT,
 ).implementation;
 
 export const accountProjectionModelModule = accountSurfaceModuleRegistry.require(
-  accountSurfaceApp,
+  accountSurfaceRuntimeSelectionPosture,
   SURFACE_APP.MODULE_ROLE.PROJECTION_MODEL,
 ).implementation;
 
 export const accountPlatformAdapterModule = accountSurfaceModuleRegistry.require(
-  accountSurfaceApp,
+  accountSurfaceRuntimeSelectionPosture,
   SURFACE_APP.MODULE_ROLE.PLATFORM_ADAPTER,
 ).implementation;
 

--- a/surface-app-contract.js
+++ b/surface-app-contract.js
@@ -7,9 +7,10 @@ import {
 } from "../constitute-protocol/src/index.js";
 import {
   defineSurfaceAppContract,
-  surfaceAppRunnerPlan,
   surfaceAppBootstrapPosture,
+  surfaceAppInstancePosture,
   surfaceAppRuntimeSelectionPosture,
+  surfaceAppRunnerPlan,
   surfaceServiceManagerOperationPosture,
   surfaceServiceManagerProofDigest,
 } from "../constitute-ui/src/surface-app-contract.js";
@@ -258,6 +259,17 @@ export const accountServiceManagerProofDigest = surfaceServiceManagerProofDigest
   observedAt: ISSUED_AT,
 });
 
+export const accountSurfaceAppInstancePosture = surfaceAppInstancePosture(accountSurfaceApp, {
+  runtimeSelectionPosture: accountSurfaceRuntimeSelectionPosture,
+  moduleBindings: accountSurfaceModules,
+  runnerPlan: accountSurfaceRunnerPlan,
+  bootstrapContract: accountSurfaceBootstrapContract,
+  bootstrapPosture: accountSurfaceBootstrapPosture,
+  serviceManagerOperationPosture: accountServiceManagerOperationPosture,
+  serviceManagerProofDigest: accountServiceManagerProofDigest,
+  issuedAt: ISSUED_AT,
+});
+
 export const accountRuntimeClientModule = accountSurfaceModuleRegistry.require(
   accountSurfaceRuntimeSelectionPosture,
   SURFACE_APP.MODULE_ROLE.RUNTIME_CLIENT,
@@ -277,6 +289,7 @@ export const accountSurfaceAttachContext = accountSurfaceApp.attachContext({
   productSurface: "constitute-account",
   runtimeSelectionPosture: accountSurfaceRuntimeSelectionPosture,
   runnerPlan: accountSurfaceRunnerPlan,
+  appInstancePosture: accountSurfaceAppInstancePosture,
   bootstrapContract: accountSurfaceBootstrapContract,
   serviceManagerSecretBoundary: accountServiceManagerSecretBoundary,
   bootstrapPosture: accountSurfaceBootstrapPosture,

--- a/surface-app-contract.js
+++ b/surface-app-contract.js
@@ -1,26 +1,15 @@
 import {
   SURFACE_APP,
-  assertServiceManagerSecretBoundary,
-  assertSurfaceAppBootstrapContract,
-  assertSurfaceAppInstancePosture,
   assertSurfaceAppManifest,
-  assertSurfaceAppRuntimeSelectionPosture,
   assertSurfaceAppContract,
-  assertSurfaceAppRunnerPlan,
 } from "../constitute-protocol/src/index.js";
 import {
   defineSurfaceAppContract,
-  surfaceAppBootstrapPosture,
-  surfaceAppInstancePosture,
-  surfaceAppRuntimeSelectionPosture,
-  surfaceAppRunnerPlan,
-  surfaceServiceManagerOperationPosture,
-  surfaceServiceManagerProofDigest,
 } from "../constitute-ui/src/surface-app-contract.js";
+import { surfaceAppSelectionReadModel } from "../constitute-ui/src/surface-selection-read-model.js";
 import { createRuntimeSurfaceClient } from "../constitute-ui/src/runtime-surface-client.js";
 import {
   createSurfaceModuleRegistry,
-  surfaceAppModuleImplementations,
 } from "../constitute-ui/src/surface-module-registry.js";
 import {
   browserStorageShellContext,
@@ -186,15 +175,6 @@ export const accountSurfaceAppManifest = assertSurfaceAppManifest({
   issuedAt: ISSUED_AT,
 });
 
-export const accountSurfaceRuntimeSelectionPosture = assertSurfaceAppRuntimeSelectionPosture(surfaceAppRuntimeSelectionPosture(
-  accountSurfaceAppManifest,
-  [accountSurfaceApp],
-  {
-    runtimeVersion: "0.1.0",
-    issuedAt: ISSUED_AT,
-  },
-));
-
 export const accountSurfaceModuleRegistry = createSurfaceModuleRegistry([
   {
     moduleRef: "constitute-ui/runtime-surface-client@0.1.0",
@@ -229,49 +209,34 @@ export const accountSurfaceModuleRegistry = createSurfaceModuleRegistry([
   },
 ]);
 
-export const accountSurfaceModules = surfaceAppModuleImplementations(
-  accountSurfaceModuleRegistry,
-  accountSurfaceRuntimeSelectionPosture,
-);
-
-export const accountSurfaceRunnerPlan = assertSurfaceAppRunnerPlan(surfaceAppRunnerPlan(accountSurfaceApp, {
+export const accountSurfaceSelectionReadModel = surfaceAppSelectionReadModel({
+  surfaceApp: accountSurfaceApp,
+  manifest: accountSurfaceAppManifest,
+  moduleRegistry: accountSurfaceModuleRegistry,
+  moduleBindingMode: "implementations",
+  productSurface: "constitute-account",
+  runtimeVersion: "0.1.0",
   issuedAt: ISSUED_AT,
-}));
-
-export const accountServiceManagerSecretBoundary = assertServiceManagerSecretBoundary(
-  accountSurfaceRunnerPlan.secretBoundary,
-);
-
-export const accountSurfaceBootstrapContract = assertSurfaceAppBootstrapContract(
-  accountSurfaceRunnerPlan.bootstrapContract,
-);
-
-export const accountSurfaceBootstrapPosture = surfaceAppBootstrapPosture(accountSurfaceApp, {
-  issuedAt: ISSUED_AT,
+  serviceManagerOperationOptions: {
+    operation: SURFACE_APP.SERVICE_MANAGER_OPERATION.HEALTH_CHECK,
+    operationId: "operation:account-ui:bootstrap-health",
+    requestedAt: ISSUED_AT,
+  },
+  serviceManagerProofDigestOptions: {
+    digestId: "proof-digest:account-ui:bootstrap",
+    observedAt: ISSUED_AT,
+  },
 });
 
-export const accountServiceManagerOperationPosture = surfaceServiceManagerOperationPosture(accountSurfaceApp, {
-  operation: SURFACE_APP.SERVICE_MANAGER_OPERATION.HEALTH_CHECK,
-  operationId: "operation:account-ui:bootstrap-health",
-  requestedAt: ISSUED_AT,
-});
-
-export const accountServiceManagerProofDigest = surfaceServiceManagerProofDigest(accountSurfaceApp, {
-  operationPosture: accountServiceManagerOperationPosture,
-  digestId: "proof-digest:account-ui:bootstrap",
-  observedAt: ISSUED_AT,
-});
-
-export const accountSurfaceAppInstancePosture = assertSurfaceAppInstancePosture(surfaceAppInstancePosture(accountSurfaceApp, {
-  runtimeSelectionPosture: accountSurfaceRuntimeSelectionPosture,
-  moduleBindings: accountSurfaceModules,
-  runnerPlan: accountSurfaceRunnerPlan,
-  bootstrapContract: accountSurfaceBootstrapContract,
-  bootstrapPosture: accountSurfaceBootstrapPosture,
-  serviceManagerOperationPosture: accountServiceManagerOperationPosture,
-  serviceManagerProofDigest: accountServiceManagerProofDigest,
-  issuedAt: ISSUED_AT,
-}));
+export const accountSurfaceRuntimeSelectionPosture = accountSurfaceSelectionReadModel.runtimeSelectionPosture;
+export const accountSurfaceModules = accountSurfaceSelectionReadModel.moduleBindings;
+export const accountSurfaceRunnerPlan = accountSurfaceSelectionReadModel.runnerPlan;
+export const accountServiceManagerSecretBoundary = accountSurfaceSelectionReadModel.serviceManagerSecretBoundary;
+export const accountSurfaceBootstrapContract = accountSurfaceSelectionReadModel.bootstrapContract;
+export const accountSurfaceBootstrapPosture = accountSurfaceSelectionReadModel.bootstrapPosture;
+export const accountServiceManagerOperationPosture = accountSurfaceSelectionReadModel.serviceManagerOperationPosture;
+export const accountServiceManagerProofDigest = accountSurfaceSelectionReadModel.serviceManagerProofDigest;
+export const accountSurfaceAppInstancePosture = accountSurfaceSelectionReadModel.appInstancePosture;
 
 export const accountRuntimeClientModule = accountSurfaceModuleRegistry.require(
   accountSurfaceRuntimeSelectionPosture,
@@ -288,14 +253,4 @@ export const accountPlatformAdapterModule = accountSurfaceModuleRegistry.require
   SURFACE_APP.MODULE_ROLE.PLATFORM_ADAPTER,
 ).implementation;
 
-export const accountSurfaceAttachContext = accountSurfaceApp.attachContext({
-  productSurface: "constitute-account",
-  runtimeSelectionPosture: accountSurfaceRuntimeSelectionPosture,
-  runnerPlan: accountSurfaceRunnerPlan,
-  appInstancePosture: accountSurfaceAppInstancePosture,
-  bootstrapContract: accountSurfaceBootstrapContract,
-  serviceManagerSecretBoundary: accountServiceManagerSecretBoundary,
-  bootstrapPosture: accountSurfaceBootstrapPosture,
-  serviceManagerOperationPosture: accountServiceManagerOperationPosture,
-  serviceManagerProofDigest: accountServiceManagerProofDigest,
-});
+export const accountSurfaceAttachContext = accountSurfaceSelectionReadModel.attachContext;

--- a/surface-app-contract.js
+++ b/surface-app-contract.js
@@ -2,12 +2,14 @@ import {
   SURFACE_APP,
   assertServiceManagerSecretBoundary,
   assertSurfaceAppBootstrapContract,
+  assertSurfaceAppManifest,
   assertSurfaceAppContract,
 } from "../constitute-protocol/src/index.js";
 import {
   defineSurfaceAppContract,
   surfaceAppRunnerPlan,
   surfaceAppBootstrapPosture,
+  surfaceAppRuntimeSelectionPosture,
   surfaceServiceManagerOperationPosture,
   surfaceServiceManagerProofDigest,
 } from "../constitute-ui/src/surface-app-contract.js";
@@ -121,6 +123,74 @@ export const accountSurfaceApp = defineSurfaceAppContract(accountSurfaceAppContr
   validate: assertSurfaceAppContract,
 });
 
+export const accountSurfaceAppManifest = assertSurfaceAppManifest({
+  kind: "surface.app.manifest",
+  manifestId: "manifest:account-ui",
+  appId: "constitute-account",
+  state: SURFACE_APP.MANIFEST_VERSION_STATE.CURRENT,
+  currentAppContractRef: "app:account-ui",
+  currentVersion: "0.1.0",
+  defaultSourceMode: SURFACE_APP.FULFILLMENT_MODE.BUNDLED,
+  requiredModuleRoles: [
+    SURFACE_APP.MODULE_ROLE.RUNTIME_CLIENT,
+    SURFACE_APP.MODULE_ROLE.PROJECTION_MODEL,
+    SURFACE_APP.MODULE_ROLE.PLATFORM_ADAPTER,
+    SURFACE_APP.MODULE_ROLE.PRODUCT_VIEW,
+  ],
+  bundledSourceRefs: ["bundle:account-ui@0.1.0"],
+  compatibilityWindow: {
+    minVersion: "0.1.0",
+    maxVersion: "0.1.x",
+    protocolRef: "protocol:surface-app:v1",
+  },
+  versions: [
+    {
+      appContractRef: "app:account-ui",
+      version: "0.1.0",
+      state: SURFACE_APP.MANIFEST_VERSION_STATE.CURRENT,
+      sourceMode: SURFACE_APP.FULFILLMENT_MODE.BUNDLED,
+      requiredModuleRoles: [
+        SURFACE_APP.MODULE_ROLE.RUNTIME_CLIENT,
+        SURFACE_APP.MODULE_ROLE.PROJECTION_MODEL,
+        SURFACE_APP.MODULE_ROLE.PLATFORM_ADAPTER,
+        SURFACE_APP.MODULE_ROLE.PRODUCT_VIEW,
+      ],
+      compatibilityWindow: {
+        minVersion: "0.1.0",
+        maxVersion: "0.1.x",
+        protocolRef: "protocol:surface-app:v1",
+      },
+      bundledSourceRefs: ["bundle:account-ui@0.1.0"],
+      grantRefs: ["grant:app:account-ui:run"],
+      runnerRequirementRefs: ["runner:req:account-ui"],
+      serviceManagerRequirementRefs: ["service-manager:req:account-ui"],
+      compatibilityRefs: ["protocol:surface-app:v1"],
+      bootstrapContractRef: "bootstrap-contract:app:account-ui",
+      releaseContractRef: "release:account-ui:local",
+      issuedAt: ISSUED_AT,
+    },
+  ],
+  appContractRefs: ["app:account-ui"],
+  grantRefs: ["grant:app:account-ui:run"],
+  runnerRequirementRefs: ["runner:req:account-ui"],
+  serviceManagerRequirementRefs: ["service-manager:req:account-ui"],
+  compatibilityRefs: ["protocol:surface-app:v1"],
+  bootstrapContractRefs: ["bootstrap-contract:app:account-ui"],
+  releaseContractRefs: ["release:account-ui:local"],
+  authorityRefs: ["authority:account-ui:local"],
+  evidenceRefs: ["build:account-ui:local"],
+  issuedAt: ISSUED_AT,
+});
+
+export const accountSurfaceRuntimeSelectionPosture = surfaceAppRuntimeSelectionPosture(
+  accountSurfaceAppManifest,
+  [accountSurfaceApp],
+  {
+    runtimeVersion: "0.1.0",
+    issuedAt: ISSUED_AT,
+  },
+);
+
 export const accountSurfaceModuleRegistry = createSurfaceModuleRegistry([
   {
     moduleRef: "constitute-ui/runtime-surface-client@0.1.0",
@@ -205,6 +275,7 @@ export const accountPlatformAdapterModule = accountSurfaceModuleRegistry.require
 
 export const accountSurfaceAttachContext = accountSurfaceApp.attachContext({
   productSurface: "constitute-account",
+  runtimeSelectionPosture: accountSurfaceRuntimeSelectionPosture,
   runnerPlan: accountSurfaceRunnerPlan,
   bootstrapContract: accountSurfaceBootstrapContract,
   serviceManagerSecretBoundary: accountServiceManagerSecretBoundary,

--- a/surface-app-contract.js
+++ b/surface-app-contract.js
@@ -2,8 +2,11 @@ import {
   SURFACE_APP,
   assertServiceManagerSecretBoundary,
   assertSurfaceAppBootstrapContract,
+  assertSurfaceAppInstancePosture,
   assertSurfaceAppManifest,
+  assertSurfaceAppRuntimeSelectionPosture,
   assertSurfaceAppContract,
+  assertSurfaceAppRunnerPlan,
 } from "../constitute-protocol/src/index.js";
 import {
   defineSurfaceAppContract,
@@ -183,14 +186,14 @@ export const accountSurfaceAppManifest = assertSurfaceAppManifest({
   issuedAt: ISSUED_AT,
 });
 
-export const accountSurfaceRuntimeSelectionPosture = surfaceAppRuntimeSelectionPosture(
+export const accountSurfaceRuntimeSelectionPosture = assertSurfaceAppRuntimeSelectionPosture(surfaceAppRuntimeSelectionPosture(
   accountSurfaceAppManifest,
   [accountSurfaceApp],
   {
     runtimeVersion: "0.1.0",
     issuedAt: ISSUED_AT,
   },
-);
+));
 
 export const accountSurfaceModuleRegistry = createSurfaceModuleRegistry([
   {
@@ -231,9 +234,9 @@ export const accountSurfaceModules = surfaceAppModuleImplementations(
   accountSurfaceRuntimeSelectionPosture,
 );
 
-export const accountSurfaceRunnerPlan = surfaceAppRunnerPlan(accountSurfaceApp, {
+export const accountSurfaceRunnerPlan = assertSurfaceAppRunnerPlan(surfaceAppRunnerPlan(accountSurfaceApp, {
   issuedAt: ISSUED_AT,
-});
+}));
 
 export const accountServiceManagerSecretBoundary = assertServiceManagerSecretBoundary(
   accountSurfaceRunnerPlan.secretBoundary,
@@ -259,7 +262,7 @@ export const accountServiceManagerProofDigest = surfaceServiceManagerProofDigest
   observedAt: ISSUED_AT,
 });
 
-export const accountSurfaceAppInstancePosture = surfaceAppInstancePosture(accountSurfaceApp, {
+export const accountSurfaceAppInstancePosture = assertSurfaceAppInstancePosture(surfaceAppInstancePosture(accountSurfaceApp, {
   runtimeSelectionPosture: accountSurfaceRuntimeSelectionPosture,
   moduleBindings: accountSurfaceModules,
   runnerPlan: accountSurfaceRunnerPlan,
@@ -268,7 +271,7 @@ export const accountSurfaceAppInstancePosture = surfaceAppInstancePosture(accoun
   serviceManagerOperationPosture: accountServiceManagerOperationPosture,
   serviceManagerProofDigest: accountServiceManagerProofDigest,
   issuedAt: ISSUED_AT,
-});
+}));
 
 export const accountRuntimeClientModule = accountSurfaceModuleRegistry.require(
   accountSurfaceRuntimeSelectionPosture,


### PR DESCRIPTION
## Summary
- refine runtime activation lifecycle, relay ingress admission, and retained projection posture
- keep route, service admission, answer materialization, adapter evidence, and release state separate
- reduce product surfaces from runtime posture instead of local route truth

## Proof
- account tests and build pass through root all check
- root docs, convergence, affected, browser, native, and all checks pass locally
- authenticated 10-minute media/resource proof held both camera previews live