### PR TITLE
Enforce materialized runtime snapshots

### DIFF
--- a/app/runtime-swarm-edge.test.js
+++ b/app/runtime-swarm-edge.test.js
@@ -633,6 +633,9 @@ test('runtime diagnostics stream replays recent events and snapshot debug payloa
 
 test('runtime attach declares snapshot materialization budget per surface', async () => {
   const runtime = loadRuntime(new Map());
+  for (let index = 0; index < 6; index += 1) {
+    await send(runtime.port, { type: 'swarm.frame.queue', payload: frameInput({ nonce: `attach-materialization-${index}` }) });
+  }
   runtime.port.onmessage({
     data: {
       type: 'runtime.attach',
@@ -646,9 +649,16 @@ test('runtime attach declares snapshot materialization budget per surface', asyn
   assert.equal(attached.materializationBudget.payloadClass, 'projection');
   assert.equal(attached.materializationBudget.copyRole, 'projection');
   assert.equal(attached.materializationBudget.privacyTier, 'safeProjection');
+  assert.equal(attached.snapshot.runtimeEvents.length <= 1, true);
+  assert.equal(attached.snapshot.materialization.delivery.droppedByReplayLimit >= 5, true);
+  assert.equal(attached.materializationBudget.limits.replayLimit, 1);
+  assert.equal(attached.materializationBudget.limits.deliveredRuntimeEventCount, attached.snapshot.runtimeEvents.length);
+  assert.equal(attached.materializationBudget.limits.estimatedSnapshotBytes > 0, true);
   assert.equal(attached.consumerFloor.kind, 'consumer.floor');
   assert.equal(attached.consumerFloor.materializationId, attached.materializationBudget.budgetId);
   const snapshot = await send(runtime.port, { type: 'runtime.snapshot.get' });
+  assert.equal(snapshot.result.runtimeEvents.length <= 1, true);
+  assert.equal(snapshot.result.materialization.delivery.deliveredRuntimeEventCount, snapshot.result.runtimeEvents.length);
   assert.equal(snapshot.result.diagnostics.materialization.some((entry) => (
     entry.budgetId === attached.materializationBudget.budgetId
       && entry.clientId === 'surface-materialization-test'

--- a/app/runtime-ui.js
+++ b/app/runtime-ui.js
@@ -1,4 +1,4 @@
-import { preparedServiceRegistry } from '../../constitute-ui/src/service-registry-model.js';
+import { preparedServiceRegistry } from 'constitute-ui';
 
 function normalizeArray(value) {
   return Array.isArray(value) ? value : [];

--- a/package-lock.json
+++ b/package-lock.json
@@ -855,7 +855,7 @@
     },
     "node_modules/constitute-protocol": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/Aux0x7F/constitute-protocol.git#3a452b5f9482f28ebd07f17549cba15b6355d530",
+      "resolved": "git+ssh://git@github.com/Aux0x7F/constitute-protocol.git#d75e53e8b31674b34e8cd57621c1fb508d70a1eb",
       "dependencies": {
         "@noble/ciphers": "^1.3.0",
         "@noble/curves": "^1.9.1",
@@ -864,7 +864,7 @@
     },
     "node_modules/constitute-ui": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/Aux0x7F/constitute-ui.git#3a677aa320282325b8def8be82473279bd70e0b8"
+      "resolved": "git+ssh://git@github.com/Aux0x7F/constitute-ui.git#52759e1325d4151712ddc13ec27516bf72066462"
     },
     "node_modules/esbuild": {
       "version": "0.25.12",

--- a/runtime.worker.js
+++ b/runtime.worker.js
@@ -1245,12 +1245,99 @@ function runtimeSnapshotConsumerFloor(endpoint, sampledAt = nowMs()) {
   });
 }
 
-function runtimeSnapshotMaterializationBudget(endpoint, sampledAt = nowMs()) {
-  const clientId = String(endpoint?.clientId || 'runtime-surface').trim() || 'runtime-surface';
+function runtimeSnapshotDeliveryLimits(endpoint) {
   const subscription = endpoint?.snapshotSubscription && typeof endpoint.snapshotSubscription === 'object'
     ? endpoint.snapshotSubscription
     : {};
+  const replayLimit = Number(subscription.replayLimit ?? RUNTIME_DIAGNOSTIC_SNAPSHOT_LIMIT);
+  const snapshotMaxBytes = Number(subscription.snapshotMaxBytes || 512 * 1024);
+  return {
+    replayLimit: Number.isFinite(replayLimit)
+      ? Math.max(0, Math.min(RUNTIME_DIAGNOSTIC_SNAPSHOT_LIMIT, replayLimit))
+      : RUNTIME_DIAGNOSTIC_SNAPSHOT_LIMIT,
+    snapshotMaxBytes: Number.isFinite(snapshotMaxBytes) && snapshotMaxBytes > 0 ? snapshotMaxBytes : 512 * 1024,
+    deliveryMode: String(subscription.mode || 'push'),
+  };
+}
+
+function objectEntryCount(value) {
+  return value && typeof value === 'object' && !Array.isArray(value) ? Object.keys(value).length : 0;
+}
+
+function estimatedRuntimeSnapshotBytes(snapshot) {
+  const eventCount = normalizeArray(snapshot.runtimeEvents).length;
+  const projectionCountValue = objectEntryCount(snapshot.projections);
+  const queueCount = objectEntryCount(snapshot.swarmQueue);
+  const activationCount = objectEntryCount(snapshot.activationResolutions);
+  const mediaCount = objectEntryCount(snapshot.mediaFulfillment);
+  const recoveryCount = objectEntryCount(snapshot.streamRecovery);
+  const serviceCountValue = normalizeArray(snapshot.serviceCatalog?.services).length
+    || objectEntryCount(snapshot.services);
+  return 48 * 1024
+    + eventCount * 1536
+    + projectionCountValue * 4096
+    + queueCount * 2048
+    + activationCount * 2048
+    + mediaCount * 1536
+    + recoveryCount * 768
+    + serviceCountValue * 2048;
+}
+
+function materializeRuntimeSnapshotForEndpoint(snapshot, endpoint, sampledAt = nowMs()) {
+  const next = {
+    ...snapshot,
+    runtimeEvents: normalizeArray(snapshot.runtimeEvents),
+  };
+  const limits = runtimeSnapshotDeliveryLimits(endpoint);
+  const sourceEventCount = next.runtimeEvents.length;
+  let droppedByReplayLimit = 0;
+  if (sourceEventCount > limits.replayLimit) {
+    next.runtimeEvents = next.runtimeEvents.slice(-limits.replayLimit);
+    droppedByReplayLimit = sourceEventCount - next.runtimeEvents.length;
+  }
+  let estimatedSnapshotBytes = estimatedRuntimeSnapshotBytes(next);
+  let droppedByByteCount = 0;
+  while (next.runtimeEvents.length > 0 && estimatedSnapshotBytes > limits.snapshotMaxBytes) {
+    next.runtimeEvents.shift();
+    droppedByByteCount += 1;
+    estimatedSnapshotBytes = estimatedRuntimeSnapshotBytes(next);
+  }
+  const deliveredRuntimeEventCount = normalizeArray(next.runtimeEvents).length;
+  next.materialization = {
+    ...(next.materialization && typeof next.materialization === 'object' ? next.materialization : {}),
+    delivery: {
+      kind: 'runtime.snapshot.materialization.delivery',
+      estimateMode: 'bounded-counts',
+      consumerRef: String(endpoint?.clientId || 'runtime-surface').trim() || 'runtime-surface',
+      sourceRuntimeEventCount: sourceEventCount,
+      deliveredRuntimeEventCount,
+      droppedByReplayLimit,
+      droppedByByteCount,
+      estimatedSnapshotBytes,
+      snapshotMaxBytes: limits.snapshotMaxBytes,
+      replayLimit: limits.replayLimit,
+      sampledAt,
+    },
+  };
+  return {
+    snapshot: next,
+    delivery: next.materialization.delivery,
+  };
+}
+
+function runtimeSnapshotMaterializationBudget(endpoint, sampledAt = nowMs(), delivery = {}) {
+  const clientId = String(endpoint?.clientId || 'runtime-surface').trim() || 'runtime-surface';
+  const limits = runtimeSnapshotDeliveryLimits(endpoint);
   const materializationId = `materialization:${clientId}:runtime-snapshot`;
+  const estimatedSnapshotBytes = Number(delivery.estimatedSnapshotBytes || 0) || 0;
+  const droppedByByteCount = Number(delivery.droppedByByteCount || 0) || 0;
+  const state = estimatedSnapshotBytes > limits.snapshotMaxBytes
+    ? SWARM.RESOURCE_POSTURE_STATE.OVER_BUDGET
+    : (droppedByByteCount > 0 ? SWARM.RESOURCE_POSTURE_STATE.PRESSURE : SWARM.RESOURCE_POSTURE_STATE.WITHIN_BUDGET);
+  const blockedReasons = [
+    ...(estimatedSnapshotBytes > limits.snapshotMaxBytes ? ['runtimeSnapshotByteCapExceeded'] : []),
+    ...(droppedByByteCount > 0 ? ['runtimeSnapshotByteCapApplied'] : []),
+  ];
   return assertMaterializationBudget({
     kind: SWARM.RECORD_KIND.MATERIALIZATION_BUDGET,
     budgetId: materializationId,
@@ -1260,12 +1347,17 @@ function runtimeSnapshotMaterializationBudget(endpoint, sampledAt = nowMs()) {
     copyRole: SWARM.MATERIALIZATION_COPY_ROLE.PROJECTION,
     transferMode: SWARM.MATERIALIZATION_TRANSFER_MODE.CLONE,
     privacyTier: SWARM.MATERIALIZATION_PRIVACY_TIER.SAFE_PROJECTION,
-    state: SWARM.RESOURCE_POSTURE_STATE.WITHIN_BUDGET,
+    state,
     limits: {
       maxFanout: endpoints.size || 1,
-      snapshotMaxBytes: Number(subscription.snapshotMaxBytes || 512 * 1024),
-      replayLimit: Number(subscription.replayLimit || 1),
-      deliveryMode: String(subscription.mode || 'push'),
+      snapshotMaxBytes: limits.snapshotMaxBytes,
+      replayLimit: limits.replayLimit,
+      deliveryMode: limits.deliveryMode,
+      estimatedSnapshotBytes,
+      sourceRuntimeEventCount: Number(delivery.sourceRuntimeEventCount || 0) || 0,
+      deliveredRuntimeEventCount: Number(delivery.deliveredRuntimeEventCount || 0) || 0,
+      droppedByReplayLimit: Number(delivery.droppedByReplayLimit || 0) || 0,
+      droppedByByteCount,
     },
     snapshotPolicy: {
       mode: 'baselineAndRepair',
@@ -1289,16 +1381,17 @@ function runtimeSnapshotMaterializationBudget(endpoint, sampledAt = nowMs()) {
       version: RUNTIME_WORKER_BUILD_ID,
     },
     consumerFloor: runtimeSnapshotConsumerFloor(endpoint, sampledAt),
+    blockedReasons,
     retentionClass: 'ephemeral.runtime-snapshot',
     issuedAt: sampledAt,
     expiresAt: sampledAt + 60_000,
   });
 }
 
-function refreshRuntimeSnapshotMaterialization(endpoint) {
+function refreshRuntimeSnapshotMaterialization(endpoint, delivery = {}) {
   if (!endpoint) return null;
   const sampledAt = nowMs();
-  endpoint.runtimeSnapshotMaterializationBudget = runtimeSnapshotMaterializationBudget(endpoint, sampledAt);
+  endpoint.runtimeSnapshotMaterializationBudget = runtimeSnapshotMaterializationBudget(endpoint, sampledAt, delivery);
   return endpoint.runtimeSnapshotMaterializationBudget;
 }
 
@@ -9060,11 +9153,12 @@ function broadcast(message) {
 function broadcastSnapshot() {
   const snapshot = runtimeSnapshot();
   for (const endpoint of endpoints.values()) {
-    const materializationBudget = refreshRuntimeSnapshotMaterialization(endpoint);
+    const materialized = materializeRuntimeSnapshotForEndpoint(snapshot, endpoint);
+    const materializationBudget = refreshRuntimeSnapshotMaterialization(endpoint, materialized.delivery);
     endpointPost(endpoint, {
       type: 'runtime.snapshot',
       buildId: RUNTIME_WORKER_BUILD_ID,
-      snapshot,
+      snapshot: materialized.snapshot,
       materializationBudget: safeClone(materializationBudget),
       consumerFloor: safeClone(materializationBudget?.consumerFloor || null),
     });
@@ -10267,13 +10361,15 @@ async function handleControlMessage(message, endpoint) {
       attachContext: message.attachContext,
     });
     startHydrationInBackground();
+    const materialized = materializeRuntimeSnapshotForEndpoint(runtimeSnapshot(), entry);
+    const materializationBudget = refreshRuntimeSnapshotMaterialization(entry, materialized.delivery);
     endpointPost(endpoint, {
       type: 'runtime.attached',
       buildId: RUNTIME_WORKER_BUILD_ID,
       clientId: entry?.clientId || '',
-      snapshot: runtimeSnapshot(),
-      materializationBudget: safeClone(entry?.runtimeSnapshotMaterializationBudget || null),
-      consumerFloor: safeClone(entry?.runtimeSnapshotMaterializationBudget?.consumerFloor || null),
+      snapshot: materialized.snapshot,
+      materializationBudget: safeClone(materializationBudget || null),
+      consumerFloor: safeClone(materializationBudget?.consumerFloor || null),
     });
     recordRuntimeEvent('runtime.attach', {
       clientId: entry?.clientId || '',
@@ -10336,12 +10432,16 @@ async function handleControlMessage(message, endpoint) {
       break;
     }
     case 'runtime.snapshot.get': {
+      const materialized = materializeRuntimeSnapshotForEndpoint(runtimeSnapshot(), endpoint);
+      const materializationBudget = refreshRuntimeSnapshotMaterialization(endpoint, materialized.delivery);
       response = {
         type: 'runtime.response',
         requestId: String(message.requestId || '').trim(),
         kind: 'runtime.snapshot.get',
         ok: true,
-        result: runtimeSnapshot(),
+        result: materialized.snapshot,
+        materializationBudget: safeClone(materializationBudget || null),
+        consumerFloor: safeClone(materializationBudget?.consumerFloor || null),
       };
       break;
     }

--- a/surface-app-contract.js
+++ b/surface-app-contract.js
@@ -2,15 +2,15 @@ import {
   SURFACE_APP,
   assertSurfaceAppManifest,
   assertSurfaceAppContract,
-} from "../constitute-protocol/src/index.js";
+} from "constitute-protocol";
 import {
   defineSurfaceAppContract,
-} from "../constitute-ui/src/surface-app-contract.js";
-import { surfaceAppSelectionReadModel } from "../constitute-ui/src/surface-selection-read-model.js";
-import { createRuntimeSurfaceClient } from "../constitute-ui/src/runtime-surface-client.js";
+} from "constitute-ui/surface-app-contract";
+import { surfaceAppSelectionReadModel } from "constitute-ui/surface-selection-read-model";
+import { createRuntimeSurfaceClient } from "constitute-ui/runtime-surface-client";
 import {
   createSurfaceModuleRegistry,
-} from "../constitute-ui/src/surface-module-registry.js";
+} from "constitute-ui/surface-module-registry";
 import {
   browserStorageShellContext,
   deriveRuntimeShellState,


### PR DESCRIPTION
## Summary
- Enforces runtime snapshot materialization budgets before product surfaces consume broad runtime state.
- Imports shared surface helpers from packages instead of local helper copies.

## Proof
- Account tests/build passed locally.
- Root docs, convergence, affected, browser, native, and all checks passed in the full train.
- Browser landscape proof passed across Account, Gateway UI, Logging UI, NVR UI, and Security.