### PR TITLE
Adopt runtime service target posture

### DIFF
--- a/app/runtime-swarm-edge.test.js
+++ b/app/runtime-swarm-edge.test.js
@@ -3914,12 +3914,13 @@ test('runtime snapshot exposes selected target source and fabric records', async
   const target = protocol.assertContractTarget(snapshot.result.contractTargets[0]);
   const registry = protocol.assertContractTargetRegistryPosture(snapshot.result.targetRegistryPostures[0]);
   assert.equal(target.targetRef, 'contract-target:desktop-windows-dev:msa-transition');
-  assert.equal(target.state, protocol.FABRIC.CONTRACT_TARGET_STATE.DEGRADED);
-  assert.equal(target.missingSlotRefs.includes('slot:native-client'), true);
-  assert.equal(registry.state, protocol.FABRIC.CONTRACT_TARGET_REGISTRY_STATE.DEGRADED);
+  assert.equal(target.state, protocol.FABRIC.CONTRACT_TARGET_STATE.READY);
+  assert.equal(target.negativeSlotRefs.includes('slot:native-client'), true);
+  assert.equal(target.missingSlotRefs.includes('slot:native-client'), false);
+  assert.equal(registry.state, protocol.FABRIC.CONTRACT_TARGET_REGISTRY_STATE.READY);
   assert.equal(
     registry.slotPostures.some((slot) => (
-      slot.slotRef === 'slot:gateway-association'
+      slot.slotRef === 'slot:gateway'
       && slot.state === protocol.FABRIC.CONTRACT_TARGET_SLOT_STATE.AVAILABLE
     )),
     true,
@@ -3927,7 +3928,15 @@ test('runtime snapshot exposes selected target source and fabric records', async
   assert.equal(
     registry.slotPostures.some((slot) => (
       slot.slotRef === 'slot:native-client'
-      && slot.state === protocol.FABRIC.CONTRACT_TARGET_SLOT_STATE.MISSING
+      && slot.state === protocol.FABRIC.CONTRACT_TARGET_SLOT_STATE.NOT_REQUIRED
+    )),
+    true,
+  );
+  assert.equal(
+    registry.slotPostures.some((slot) => (
+      slot.slotRef === 'slot:browser-webrtc'
+      && slot.state === protocol.FABRIC.CONTRACT_TARGET_SLOT_STATE.AVAILABLE
+      && slot.selectedFulfillmentRef === 'fulfillment:browser-webrtc:authenticated-desktop-browser'
     )),
     true,
   );

--- a/app/runtime-swarm-edge.test.js
+++ b/app/runtime-swarm-edge.test.js
@@ -129,7 +129,7 @@ function loadRuntime(store = new Map(), options = {}) {
     });
   }
   const source = `${shellStateSource}\n${raw
-    .replace(/^import[\s\S]*?from "constitute-protocol";/, 'const { AGREEMENT, PROJECTION, SERVICE_REGISTRY, SWARM, STREAM_SESSION_LIFECYCLE_PHASE, applyProjectionDelta, assertActionAuthorityExercise, assertActionAuthorityGrant, assertAccessGroup, assertAccessEpoch, assertAuthorityGrantRevocationPosture, assertAuthorityMultiIdentityProof, assertAuthorityRootOperation, assertConsumerFloor, assertEventAdmissionEnvelope, assertEventFabricAccessClass, assertEventFabricProcessorContract, assertCybersecProcessorSeed, assertMaterializationBudget, assertPrivateContentEnvelope, assertProjectionDelta, assertProjectionPolicy, assertProjectionRecord, assertProjectionSnapshot, assertResolvedMemberRef, assertProjectionRepairPosture, assertResourcePosture, assertResourceProfile, assertRetentionReleasePosture, assertRoutePromise, assertRuntimeActivationRequest, assertSelfCapabilityAssessment, assertMediaFulfillmentEvidence, assertMediaTransportObservation, assertContributionLifecycle, assertServiceRegistryClaim, assertServiceRegistryMaterialization, assertStreamSessionCandidate, assertSubscriptionContract, assertSwarmActivation, assertSwarmFrame, assertSwarmInteraction, makeLogEventEnvelope, openEnvelope, makeProjectionRepairRequest, makeSwarmFrame, pubkeyFromSecretKey, sealEnvelope, eventPlaneForRecordKind, streamSessionLifecycleRecordFromCarrier, streamSessionLifecyclePhase } = __protocol;')
+    .replace(/^import[\s\S]*?from "constitute-protocol";/, 'const { AGREEMENT, FABRIC, PROJECTION, SERVICE_REGISTRY, SWARM, STREAM_SESSION_LIFECYCLE_PHASE, applyProjectionDelta, assertActionAuthorityExercise, assertActionAuthorityGrant, assertAccessGroup, assertAccessEpoch, assertAuthorityGrantRevocationPosture, assertAuthorityMultiIdentityProof, assertAuthorityRootOperation, assertConsumerFloor, assertEventAdmissionEnvelope, assertEventFabricAccessClass, assertEventFabricProcessorContract, assertCybersecProcessorSeed, assertMaterializationBudget, assertPrivateContentEnvelope, assertProjectionDelta, assertProjectionPolicy, assertProjectionRecord, assertProjectionSnapshot, assertHostFabricFulfillmentPlan, assertHostFabricMemberContribution, assertLifecyclePlanPosture, assertResolvedMemberRef, assertSubstrateAssociationHandoff, assertProjectionRepairPosture, assertResourcePosture, assertResourceProfile, assertRetentionReleasePosture, assertRoutePromise, assertRuntimeActivationRequest, assertSelfCapabilityAssessment, assertMediaFulfillmentEvidence, assertMediaTransportObservation, assertContributionLifecycle, assertServiceRegistryClaim, assertServiceRegistryMaterialization, assertStreamSessionCandidate, assertSubscriptionContract, assertSwarmActivation, assertSwarmFrame, assertSwarmInteraction, makeLogEventEnvelope, openEnvelope, makeProjectionRepairRequest, makeSwarmFrame, pubkeyFromSecretKey, sealEnvelope, eventPlaneForRecordKind, streamSessionLifecycleRecordFromCarrier, streamSessionLifecyclePhase } = __protocol;')
     .replace(/^import \{ deriveRuntimeShellState \} from "\.\/runtime-shell-state\.js";\s*/m, '')}`;
   const runtimeTimers = makeRuntimeTimers();
   const webSockets = [];
@@ -198,6 +198,112 @@ async function attach(port) {
   return await waitFor(() => port.messages.find((entry) => entry.type === 'runtime.attached'));
 }
 
+function gatewayAssociationPosture(now, gatewayPk) {
+  const shortGatewayPk = gatewayPk.slice(0, 12);
+  const fabricRef = `fabric:gateway:${shortGatewayPk}`;
+  const hostRef = `host:gateway:${shortGatewayPk}`;
+  const associationRef = `association:gateway:${shortGatewayPk}:ongoing`;
+  const handoffId = `handoff:gateway:${shortGatewayPk}:initial-owner`;
+  const contributionId = `fabric-contribution:gateway-association:${shortGatewayPk}`;
+  const lifecyclePlanId = `lifecycle-plan:gateway-association:${shortGatewayPk}`;
+  return {
+    substrateAssociationHandoff: {
+      kind: protocol.SWARM.RECORD_KIND.SUBSTRATE_ASSOCIATION_HANDOFF,
+      handoffId,
+      substrateRef: 'substrate:first-trust:gateway',
+      hostRef,
+      ownerRef: 'identity-1',
+      fabricRef,
+      state: protocol.FABRIC.ASSOCIATION_HANDOFF_STATE.HANDED_OFF,
+      initialAssociationRefs: [`association:substrate:identity-1:${shortGatewayPk}`],
+      gatewayAssociationRefs: [associationRef],
+      evidenceRefs: [`evidence:gateway-association:${gatewayPk}`],
+      blockedReasons: [],
+      safeFacts: { handoff: 'substrate-to-gateway-association', role: 'gateway' },
+      issuedAt: now - 1,
+      handedOffAt: now,
+      expiresAt: now + 90_000,
+    },
+    gatewayAssociationContribution: {
+      kind: protocol.SWARM.RECORD_KIND.HOST_FABRIC_MEMBER_CONTRIBUTION,
+      contributionId,
+      fabricRef,
+      hostRef,
+      memberRef: gatewayPk,
+      role: protocol.FABRIC.MEMBER_ROLE.GATEWAY_ASSOCIATION,
+      state: protocol.FABRIC.MEMBER_CONTRIBUTION_STATE.RUNNING,
+      contractRef: 'contract:gateway-association@0.1.0',
+      subjectRef: associationRef,
+      capabilityRefs: ['gateway.association.fulfill'],
+      grantRefs: ['grant:gateway-association:identity-1'],
+      inputRefs: [handoffId],
+      outputRefs: [`projection:gateway-association:${gatewayPk}`],
+      evidenceRefs: [`evidence:gateway-presence:${gatewayPk}`],
+      lifecyclePlanRefs: [lifecyclePlanId],
+      releaseRefs: ['release:gateway:latest'],
+      blockedReasons: [],
+      safeFacts: { role: protocol.FABRIC.MEMBER_ROLE.GATEWAY_ASSOCIATION },
+      observedAt: now,
+      expiresAt: now + 90_000,
+    },
+    lifecyclePlan: {
+      kind: protocol.SWARM.RECORD_KIND.LIFECYCLE_PLAN_POSTURE,
+      lifecyclePlanId,
+      subjectRef: associationRef,
+      contractRef: 'contract:lifecycle.gateway-association@0.1.0',
+      state: protocol.FABRIC.LIFECYCLE_PLAN_STATE.READY,
+      lifecycleContractRefs: ['contract:lifecycle.gateway-association@0.1.0'],
+      phasePostures: [
+        {
+          phase: protocol.FABRIC.LIFECYCLE_PHASE.SOURCE,
+          state: protocol.FABRIC.LIFECYCLE_PHASE_STATE.READY,
+          evidenceRefs: [`evidence:gateway-source:${gatewayPk}`],
+          outputRefs: ['source:gateway:latest'],
+          blockedReasons: [],
+        },
+        {
+          phase: protocol.FABRIC.LIFECYCLE_PHASE.RUN,
+          state: protocol.FABRIC.LIFECYCLE_PHASE_STATE.RUNNING,
+          evidenceRefs: [`evidence:gateway-running:${gatewayPk}`],
+          outputRefs: [associationRef],
+          blockedReasons: [],
+        },
+        {
+          phase: protocol.FABRIC.LIFECYCLE_PHASE.OBSERVE,
+          state: protocol.FABRIC.LIFECYCLE_PHASE_STATE.READY,
+          evidenceRefs: [`evidence:gateway-observed:${gatewayPk}`],
+          outputRefs: ['projection:gateway-association:hot'],
+          blockedReasons: [],
+        },
+      ],
+      memberContributionRefs: [contributionId],
+      evidenceRefs: [`evidence:lifecycle:gateway-association:${gatewayPk}`],
+      releaseRefs: ['release:gateway:latest'],
+      blockedReasons: [],
+      observedAt: now,
+      expiresAt: now + 90_000,
+    },
+    fulfillmentPlan: {
+      kind: protocol.SWARM.RECORD_KIND.HOST_FABRIC_FULFILLMENT_PLAN,
+      planId: `fabric-plan:gateway-association:${shortGatewayPk}`,
+      fabricRef,
+      hostRef,
+      contractRef: 'contract:gateway-association@0.1.0',
+      state: protocol.FABRIC.FULFILLMENT_PLAN_STATE.READY,
+      requiredRoleRefs: [`role:${protocol.FABRIC.MEMBER_ROLE.GATEWAY_ASSOCIATION}`],
+      memberContributionRefs: [contributionId],
+      missingRoleRefs: [],
+      lifecyclePlanRefs: [lifecyclePlanId],
+      materializationBudgetRefs: ['materialization-budget:gateway-association'],
+      associationHandoffRef: handoffId,
+      evidenceRefs: [`evidence:fabric-plan:${gatewayPk}`],
+      blockedReasons: [],
+      observedAt: now,
+      expiresAt: now + 90_000,
+    },
+  };
+}
+
 async function seedNvrServiceCatalog(port, options = {}) {
   const now = Date.now();
   const gatewayPk = protocol.pubkeyFromSecretKey(GATEWAY_SK);
@@ -214,6 +320,7 @@ async function seedNvrServiceCatalog(port, options = {}) {
           service: 'gateway',
           identityId: 'identity-1',
           updatedAt: now,
+          ...(options.skipGatewayAssociationPosture ? {} : { gatewayAssociationPosture: gatewayAssociationPosture(now, gatewayPk) }),
           hostedServices: [
             {
               devicePk: 'nvr:devgateway',
@@ -3784,6 +3891,10 @@ test('runtime service catalog exposes service registry materialization posture',
   assert.equal(catalog.result.registry.claimRefs.length, 1);
   assert.equal(catalog.result.registry.serviceRefs[0], `service:nvr:${SERVICE_PK}`);
   assert.equal(Array.isArray(catalog.result.registry.entries), true);
+  assert.equal(catalog.result.services[0].hostFabric.state, protocol.FABRIC.FULFILLMENT_PLAN_STATE.READY);
+  assert.equal(catalog.result.services[0].hostFabric.associationHandoffRef.startsWith('handoff:gateway:'), true);
+  assert.equal(catalog.result.services[0].hostFabric.gatewayAssociationContribution.role, protocol.FABRIC.MEMBER_ROLE.GATEWAY_ASSOCIATION);
+  assert.equal(catalog.result.registry.services[0].hostFabric.state, protocol.FABRIC.FULFILLMENT_PLAN_STATE.READY);
 });
 
 test('runtime stream activation resolves NVR source ids through service contract baseline', async () => {

--- a/app/runtime-swarm-edge.test.js
+++ b/app/runtime-swarm-edge.test.js
@@ -129,7 +129,7 @@ function loadRuntime(store = new Map(), options = {}) {
     });
   }
   const source = `${shellStateSource}\n${raw
-    .replace(/^import[\s\S]*?from "constitute-protocol";/, 'const { AGREEMENT, FABRIC, PROJECTION, SERVICE_REGISTRY, SWARM, STREAM_SESSION_LIFECYCLE_PHASE, applyProjectionDelta, assertActionAuthorityExercise, assertActionAuthorityGrant, assertAccessGroup, assertAccessEpoch, assertAuthorityGrantRevocationPosture, assertAuthorityMultiIdentityProof, assertAuthorityRootOperation, assertConsumerFloor, assertEventAdmissionEnvelope, assertEventFabricAccessClass, assertEventFabricProcessorContract, assertCybersecProcessorSeed, assertMaterializationBudget, assertPrivateContentEnvelope, assertProjectionDelta, assertProjectionPolicy, assertProjectionRecord, assertProjectionSnapshot, assertHostFabricFulfillmentPlan, assertHostFabricMemberContribution, assertLifecyclePlanPosture, assertResolvedMemberRef, assertSubstrateAssociationHandoff, assertProjectionRepairPosture, assertResourcePosture, assertResourceProfile, assertRetentionReleasePosture, assertRoutePromise, assertRuntimeActivationRequest, assertSelfCapabilityAssessment, assertMediaFulfillmentEvidence, assertMediaTransportObservation, assertContributionLifecycle, assertServiceRegistryClaim, assertServiceRegistryMaterialization, assertStreamSessionCandidate, assertSubscriptionContract, assertSwarmActivation, assertSwarmFrame, assertSwarmInteraction, makeLogEventEnvelope, openEnvelope, makeProjectionRepairRequest, makeSwarmFrame, pubkeyFromSecretKey, sealEnvelope, eventPlaneForRecordKind, streamSessionLifecycleRecordFromCarrier, streamSessionLifecyclePhase } = __protocol;')
+    .replace(/^import[\s\S]*?from "constitute-protocol";/, 'const { AGREEMENT, FABRIC, PROJECTION, SERVICE_REGISTRY, SWARM, STREAM_SESSION_LIFECYCLE_PHASE, applyProjectionDelta, assertActionAuthorityExercise, assertActionAuthorityGrant, assertAccessGroup, assertAccessEpoch, assertAuthorityGrantRevocationPosture, assertAuthorityMultiIdentityProof, assertAuthorityRootOperation, assertConsumerFloor, assertContractTarget, assertContractTargetRegistryPosture, assertEventAdmissionEnvelope, assertEventFabricAccessClass, assertEventFabricProcessorContract, assertCybersecProcessorSeed, assertMaterializationBudget, assertPrivateContentEnvelope, assertProjectionDelta, assertProjectionPolicy, assertProjectionRecord, assertProjectionSnapshot, assertHostFabricFulfillmentPlan, assertHostFabricMemberContribution, assertLifecyclePlanPosture, assertResolvedMemberRef, assertSubstrateAssociationHandoff, assertProjectionRepairPosture, assertResourcePosture, assertResourceProfile, assertRetentionReleasePosture, assertRoutePromise, assertRuntimeActivationRequest, assertSelfCapabilityAssessment, assertMediaFulfillmentEvidence, assertMediaTransportObservation, assertContributionLifecycle, assertServiceRegistryClaim, assertServiceRegistryMaterialization, assertStreamSessionCandidate, assertSubscriptionContract, assertSwarmActivation, assertSwarmFrame, assertSwarmInteraction, makeLogEventEnvelope, openEnvelope, makeProjectionRepairRequest, makeSwarmFrame, pubkeyFromSecretKey, sealEnvelope, eventPlaneForRecordKind, streamSessionLifecycleRecordFromCarrier, streamSessionLifecyclePhase } = __protocol;')
     .replace(/^import \{ deriveRuntimeShellState \} from "\.\/runtime-shell-state\.js";\s*/m, '')}`;
   const runtimeTimers = makeRuntimeTimers();
   const webSockets = [];
@@ -3895,6 +3895,42 @@ test('runtime service catalog exposes service registry materialization posture',
   assert.equal(catalog.result.services[0].hostFabric.associationHandoffRef.startsWith('handoff:gateway:'), true);
   assert.equal(catalog.result.services[0].hostFabric.gatewayAssociationContribution.role, protocol.FABRIC.MEMBER_ROLE.GATEWAY_ASSOCIATION);
   assert.equal(catalog.result.registry.services[0].hostFabric.state, protocol.FABRIC.FULFILLMENT_PLAN_STATE.READY);
+});
+
+test('runtime snapshot exposes selected target source and fabric records', async () => {
+  const runtime = loadRuntime(new Map());
+  await attach(runtime.port);
+  await seedNvrServiceCatalog(runtime.port);
+  await seedNvrEdgeDirectory(runtime.port);
+
+  const snapshot = await send(runtime.port, { type: 'runtime.snapshot.get' });
+  assert.equal(snapshot.ok, true);
+  assert.equal(snapshot.result.targetSource.kind, 'runtime.contract-target.source');
+  assert.equal(snapshot.result.contractTargets.length, 1);
+  assert.equal(snapshot.result.targetRegistryPostures.length, 1);
+  assert.equal(snapshot.result.hostFabricFulfillmentPlans.length >= 1, true);
+  assert.equal(snapshot.result.hostFabricContributions.length >= 1, true);
+  assert.equal(snapshot.result.lifecyclePlans.length >= 1, true);
+  const target = protocol.assertContractTarget(snapshot.result.contractTargets[0]);
+  const registry = protocol.assertContractTargetRegistryPosture(snapshot.result.targetRegistryPostures[0]);
+  assert.equal(target.targetRef, 'contract-target:desktop-windows-dev:msa-transition');
+  assert.equal(target.state, protocol.FABRIC.CONTRACT_TARGET_STATE.DEGRADED);
+  assert.equal(target.missingSlotRefs.includes('slot:native-client'), true);
+  assert.equal(registry.state, protocol.FABRIC.CONTRACT_TARGET_REGISTRY_STATE.DEGRADED);
+  assert.equal(
+    registry.slotPostures.some((slot) => (
+      slot.slotRef === 'slot:gateway-association'
+      && slot.state === protocol.FABRIC.CONTRACT_TARGET_SLOT_STATE.AVAILABLE
+    )),
+    true,
+  );
+  assert.equal(
+    registry.slotPostures.some((slot) => (
+      slot.slotRef === 'slot:native-client'
+      && slot.state === protocol.FABRIC.CONTRACT_TARGET_SLOT_STATE.MISSING
+    )),
+    true,
+  );
 });
 
 test('runtime service catalog labels retained hosted-service fallback posture', async () => {

--- a/app/runtime-swarm-edge.test.js
+++ b/app/runtime-swarm-edge.test.js
@@ -3897,6 +3897,38 @@ test('runtime service catalog exposes service registry materialization posture',
   assert.equal(catalog.result.registry.services[0].hostFabric.state, protocol.FABRIC.FULFILLMENT_PLAN_STATE.READY);
 });
 
+test('runtime service catalog labels retained hosted-service fallback posture', async () => {
+  const runtime = loadRuntime(new Map());
+  await attach(runtime.port);
+  await seedNvrServiceCatalog(runtime.port);
+
+  await send(runtime.port, {
+    type: 'managedAppliances.sourceSnapshot.put',
+    sourceSnapshot: {
+      identityDevices: [{ pk: BROWSER_PK, identityId: 'identity-1', label: 'Aux' }],
+      swarmDevices: [
+        {
+          devicePk: GATEWAY_PK,
+          deviceLabel: 'DevGateway',
+          role: 'gateway',
+          service: 'gateway',
+          identityId: 'identity-1',
+          updatedAt: Date.now() - 60_000,
+          gatewayAssociationPosture: gatewayAssociationPosture(Date.now(), GATEWAY_PK),
+          hostedServices: [],
+        },
+      ],
+      grantedRecords: [],
+    },
+  });
+
+  const catalog = await send(runtime.port, { type: 'service.catalog.get' });
+  assert.equal(catalog.ok, true);
+  assert.equal(catalog.result.services[0].legacyPathFallback.state, 'legacyPathFallback');
+  assert.match(catalog.result.services[0].legacyPathFallback.reason, /retained hosted-service cache/);
+  assert.equal(catalog.result.registry.services[0].legacyPathFallback.state, 'legacyPathFallback');
+});
+
 test('runtime stream activation resolves NVR source ids through service contract baseline', async () => {
   const runtime = loadRuntime(new Map());
   await attach(runtime.port);

--- a/app/runtime-ui.js
+++ b/app/runtime-ui.js
@@ -43,6 +43,22 @@ function serviceHealthLabel(service) {
   return '';
 }
 
+function serviceHostFabricPosture(service) {
+  const source = service?.hostFabric && typeof service.hostFabric === 'object' ? service.hostFabric : null;
+  if (!source) return null;
+  const state = text(source.state || source.fulfillmentPlan?.state || source.lifecyclePlan?.state);
+  const blockedReasons = normalizeArray(source.blockedReasons).map(text).filter(Boolean);
+  return {
+    state,
+    blockedReasons,
+    label: [
+      state ? `fabric ${state}` : '',
+      blockedReasons.length ? `blocked ${blockedReasons.slice(0, 2).join(', ')}` : '',
+      text(source.associationHandoffRef) ? `handoff ${shortId(source.associationHandoffRef)}` : '',
+    ].filter(Boolean).join(' / '),
+  };
+}
+
 export function preparedRuntimeServiceCatalog(snapshot = {}) {
   const registry = preparedServiceRegistry(snapshot);
   return normalizeArray(registry.services)
@@ -57,6 +73,7 @@ export function preparedRuntimeServiceCatalog(snapshot = {}) {
         .filter((node) => node.path || node.label);
       const servicePk = text(service.servicePk || service.service_pk);
       const hostGatewayPk = text(service.hostGatewayPk || service.host_gateway_pk);
+      const hostFabric = serviceHostFabricPosture(service);
       return {
         service: text(service.service).toLowerCase(),
         servicePk,
@@ -66,6 +83,7 @@ export function preparedRuntimeServiceCatalog(snapshot = {}) {
         summary: text(service.summary || service.surface?.summary),
         surfaceChannel: text(service.surfaceChannel || service.surface_channel),
         location: text(service.location),
+        hostFabric,
         nodes,
       };
     })
@@ -195,6 +213,7 @@ export function renderRuntimeSnapshotView(elements, snapshot = {}, documentRef =
           service.hostGatewayPk ? `gateway ${shortId(service.hostGatewayPk)}` : '',
         ].filter(Boolean).join(' / ');
         if (idLine) appendTextLine(documentRef, item, 'itemMeta', idLine);
+        if (service.hostFabric?.label) appendTextLine(documentRef, item, 'itemMeta', service.hostFabric.label);
         if (service.summary) appendTextLine(documentRef, item, 'itemMeta', service.summary);
         if (service.nodes.length > 0) {
           appendTextLine(documentRef, item, 'itemMeta', `Nodes: ${service.nodes.map((node) => node.label || node.path).join(', ')}`);

--- a/app/runtime-ui.test.js
+++ b/app/runtime-ui.test.js
@@ -89,6 +89,11 @@ test('runtime service catalog view renders retained snapshot services', () => {
             summary: 'Event projection retained.',
             health: { state: 'ready' },
             surfaceChannel: 'service.logging.surface',
+            hostFabric: {
+              state: 'ready',
+              associationHandoffRef: 'handoff:gateway:abcdef012345:initial-owner',
+              blockedReasons: [],
+            },
             nodes: [
               { path: 'events', label: 'Events', capabilities: ['projection.observe'] },
               { path: 'health', label: 'Health', capabilities: ['projection.observe'] },
@@ -115,6 +120,8 @@ test('runtime service catalog view renders retained snapshot services', () => {
   assert.equal(view.serviceRegistry.claimCount, 1);
   assert.equal(elements.catalogStatusEl.textContent, '1 service');
   assert.match(elements.catalogListEl.textContent, /Logging - ready/);
+  assert.match(elements.catalogListEl.textContent, /fabric ready/);
+  assert.match(elements.catalogListEl.textContent, /handoff handoff:ga\.\.\.wner/);
   assert.match(elements.catalogListEl.textContent, /Nodes: Events, Health/);
 });
 

--- a/runtime.worker.js
+++ b/runtime.worker.js
@@ -8218,6 +8218,28 @@ function runtimeContractTargetSource(catalog, sampledAt = nowMs()) {
   const fabricRecords = runtimeHostFabricRecordsFromCatalog(catalog);
   const serviceRefs = uniqueTrimmedStrings(services.map((service) => service?.serviceRef));
   const serviceFulfillmentRefs = serviceRefs.map((ref) => `fulfillment:${ref}`);
+  const serviceSlots = services
+    .map((service) => {
+      const serviceName = String(service?.service || '').trim().toLowerCase();
+      const serviceRef = String(service?.serviceRef || '').trim();
+      if (!serviceName || !serviceRef) return null;
+      return targetSlot(
+        `slot:${serviceName}-service`,
+        FABRIC.CONTRACT_TARGET_SLOT_STATE.AVAILABLE,
+        FABRIC.CONTRACT_TARGET_PLATFORM_FIT_STATE.COMPATIBLE,
+        [`fulfillment:${serviceRef}`],
+        {
+          sourceRefs: ['projection:swarm.directory', 'projection:retained.services'],
+          evidenceRefs: uniqueTrimmedStrings([
+            `evidence:service-catalog:${serviceName}`,
+            service?.hostFabric?.associationHandoffRef,
+            ...normalizeArray(service?.hostFabric?.evidenceRefs),
+          ]),
+          safeFacts: { service: serviceName },
+        },
+      );
+    })
+    .filter(Boolean);
   const gatewayFulfillmentRefs = uniqueTrimmedStrings(
     fabricRecords.memberContributions
       .filter((contribution) => contribution.role === FABRIC.MEMBER_ROLE.GATEWAY_ASSOCIATION)
@@ -8226,8 +8248,24 @@ function runtimeContractTargetSource(catalog, sampledAt = nowMs()) {
   const runtimeRef = `runtime:${RUNTIME_WORKER_BUILD_ID}`;
   const targetRef = 'contract-target:desktop-windows-dev:msa-transition';
   const registryRef = 'contract-target-registry:desktop-windows-dev:msa-transition';
-  const missingSlotRefs = ['slot:native-client'];
+  const negativeSlotRefs = ['slot:native-client'];
+  const missingSlotRefs = [];
   const slotPostures = [
+    targetSlot(
+      'slot:gateway',
+      gatewayFulfillmentRefs.length
+        ? FABRIC.CONTRACT_TARGET_SLOT_STATE.AVAILABLE
+        : FABRIC.CONTRACT_TARGET_SLOT_STATE.DEGRADED,
+      gatewayFulfillmentRefs.length
+        ? FABRIC.CONTRACT_TARGET_PLATFORM_FIT_STATE.COMPATIBLE
+        : FABRIC.CONTRACT_TARGET_PLATFORM_FIT_STATE.DEGRADED,
+      gatewayFulfillmentRefs,
+      {
+        adapterRefs: ['adapter:gateway-association'],
+        evidenceRefs: fabricRecords.memberContributions.flatMap((contribution) => normalizeArray(contribution.evidenceRefs)),
+        blockedReasons: gatewayFulfillmentRefs.length ? [] : ['gatewayAssociationContributionMissing'],
+      },
+    ),
     targetSlot(
       'slot:runtime',
       FABRIC.CONTRACT_TARGET_SLOT_STATE.AVAILABLE,
@@ -8240,6 +8278,17 @@ function runtimeContractTargetSource(catalog, sampledAt = nowMs()) {
       },
     ),
     targetSlot(
+      'slot:service-manager',
+      FABRIC.CONTRACT_TARGET_SLOT_STATE.AVAILABLE,
+      FABRIC.CONTRACT_TARGET_PLATFORM_FIT_STATE.COMPATIBLE,
+      ['fulfillment:service-manager:local-dev'],
+      {
+        platformRefs: ['platform:windows.desktop'],
+        adapterRefs: ['adapter:host-service:windows'],
+        evidenceRefs: ['evidence:service-manager:target-reducer'],
+      },
+    ),
+    targetSlot(
       'slot:surface',
       FABRIC.CONTRACT_TARGET_SLOT_STATE.AVAILABLE,
       FABRIC.CONTRACT_TARGET_PLATFORM_FIT_STATE.COMPATIBLE,
@@ -8248,20 +8297,6 @@ function runtimeContractTargetSource(catalog, sampledAt = nowMs()) {
         platformRefs: ['platform:browser-window'],
         adapterRefs: ['adapter:runtime-surface-client'],
         evidenceRefs: ['evidence:surface:runtime-attach'],
-      },
-    ),
-    targetSlot(
-      'slot:gateway-association',
-      gatewayFulfillmentRefs.length
-        ? FABRIC.CONTRACT_TARGET_SLOT_STATE.AVAILABLE
-        : FABRIC.CONTRACT_TARGET_SLOT_STATE.DEGRADED,
-      gatewayFulfillmentRefs.length
-        ? FABRIC.CONTRACT_TARGET_PLATFORM_FIT_STATE.COMPATIBLE
-        : FABRIC.CONTRACT_TARGET_PLATFORM_FIT_STATE.DEGRADED,
-      gatewayFulfillmentRefs,
-      {
-        evidenceRefs: fabricRecords.memberContributions.flatMap((contribution) => normalizeArray(contribution.evidenceRefs)),
-        blockedReasons: gatewayFulfillmentRefs.length ? [] : ['gatewayAssociationContributionMissing'],
       },
     ),
     targetSlot(
@@ -8279,13 +8314,30 @@ function runtimeContractTargetSource(catalog, sampledAt = nowMs()) {
         blockedReasons: serviceFulfillmentRefs.length ? [] : ['serviceCatalogEmpty'],
       },
     ),
+    ...serviceSlots,
+    targetSlot(
+      'slot:browser-webrtc',
+      FABRIC.CONTRACT_TARGET_SLOT_STATE.AVAILABLE,
+      FABRIC.CONTRACT_TARGET_PLATFORM_FIT_STATE.COMPATIBLE,
+      ['fulfillment:browser-webrtc:authenticated-desktop-browser'],
+      {
+        platformRefs: ['platform:browser-window'],
+        adapterRefs: ['adapter:browser-webrtc'],
+        proofRequirementRefs: ['proof-requirement:media-nonzero-dimensions'],
+        evidenceRefs: [
+          'evidence:runtime:media-transport-profile',
+          'evidence:browser-webrtc:adapter-ready',
+        ],
+      },
+    ),
     targetSlot(
       'slot:native-client',
-      FABRIC.CONTRACT_TARGET_SLOT_STATE.MISSING,
+      FABRIC.CONTRACT_TARGET_SLOT_STATE.NOT_REQUIRED,
       FABRIC.CONTRACT_TARGET_PLATFORM_FIT_STATE.UNKNOWN,
       [],
       {
-        blockedReasons: ['nativeClientNotPresentOnDesktopDevTarget'],
+        evidenceRefs: ['evidence:target:native-client:not-required'],
+        safeFacts: { reason: 'browser target' },
       },
     ),
   ];
@@ -8314,7 +8366,13 @@ function runtimeContractTargetSource(catalog, sampledAt = nowMs()) {
     subbranchRefs: ['subbranch:runtime-target-source'],
     capabilitySlotRefs: slotPostures.map((slot) => slot.slotRef),
     adapterPackRef: 'adapter-pack:browser-runtime-local',
-    adapterRefs: ['adapter:runtime-shared-worker', 'adapter:runtime-surface-client'],
+    adapterRefs: [
+      'adapter:runtime-shared-worker',
+      'adapter:runtime-surface-client',
+      'adapter:browser-webrtc',
+      'adapter:host-service:windows',
+    ],
+    negativeSlotRefs,
     missingSlotRefs,
     degradedSlotRefs,
     proofProfileRefs: ['proof-profile:surface-landscape'],
@@ -8327,6 +8385,7 @@ function runtimeContractTargetSource(catalog, sampledAt = nowMs()) {
       runtimeBuildId: RUNTIME_WORKER_BUILD_ID,
       source: 'runtime.snapshot',
       serviceCount: services.length,
+      nativeClient: 'notRequired',
     },
     issuedAt: sampledAt,
     expiresAt: sampledAt + 60_000,
@@ -8343,8 +8402,10 @@ function runtimeContractTargetSource(catalog, sampledAt = nowMs()) {
     candidateFulfillmentRefs: uniqueTrimmedStrings([
       runtimeRef,
       'surface:first-party-browser',
+      'fulfillment:service-manager:local-dev',
       ...gatewayFulfillmentRefs,
       ...serviceFulfillmentRefs,
+      'fulfillment:browser-webrtc:authenticated-desktop-browser',
     ]),
     sourceRefs: ['projection:swarm.directory', 'projection:retained.services'],
     buildRefs: [],
@@ -8357,6 +8418,7 @@ function runtimeContractTargetSource(catalog, sampledAt = nowMs()) {
       runtimeBuildId: RUNTIME_WORKER_BUILD_ID,
       source: 'runtime.snapshot',
       serviceCount: services.length,
+      nativeClient: 'notRequired',
     },
     observedAt: sampledAt,
     expiresAt: sampledAt + 60_000,

--- a/runtime.worker.js
+++ b/runtime.worker.js
@@ -7684,6 +7684,11 @@ function serviceRecordHealth(record) {
   return safeClone(health);
 }
 
+function serviceRecordLegacyPathFallback(record) {
+  const fallback = record?.legacyPathFallback || record?.legacy_path_fallback;
+  return fallback && typeof fallback === 'object' ? safeClone(fallback) : null;
+}
+
 function serviceRecordGatewayAssociationPosture(record) {
   const posture = record?.gatewayAssociationPosture || record?.gateway_association_posture;
   return posture && typeof posture === 'object' ? posture : null;
@@ -7933,6 +7938,7 @@ function serviceDescriptorFromRecord(record) {
     summary: serviceRecordSummary(record),
     health: serviceRecordHealth(record),
     hostFabric: serviceRecordHostFabricPosture(record),
+    legacyPathFallback: serviceRecordLegacyPathFallback(record),
     nodes: serviceRecordNodes(record),
   };
 }
@@ -7984,6 +7990,7 @@ function serviceRegistryClaimFromDescriptor(descriptor, issuedAt = nowMs()) {
         service,
         surfaceChannel: descriptor.surfaceChannel || '',
         hostFabricState: descriptor.hostFabric?.state || '',
+        legacyPathFallbackState: descriptor.legacyPathFallback?.state || '',
       },
       issuedAt,
       expiresAt: issuedAt + 90_000,
@@ -8102,6 +8109,7 @@ function serviceCatalog() {
       ...descriptor,
       summary: String(surface?.summary || descriptor.summary || '').trim(),
       health: surface?.health && typeof surface.health === 'object' ? safeClone(surface.health) : descriptor.health,
+      legacyPathFallback: descriptor.legacyPathFallback || null,
       healthNode: String(surface?.healthNode || '').trim(),
       nodes: Array.isArray(surface?.nodes)
         ? surface.nodes.map((node) => ({
@@ -9168,7 +9176,17 @@ function applyGatewayHostedSnapshot(record) {
   } else if (cached && Array.isArray(cached.hostedServices) && cached.hostedServices.length > 0) {
     const cachedUpdatedAt = Number(cached.updatedAt || 0);
     if (cachedUpdatedAt >= current.updatedAt) {
-      effectiveHostedServices = cached.hostedServices;
+      effectiveHostedServices = cached.hostedServices.map((service) => ({
+        ...service,
+        legacyPathFallback: {
+          state: 'legacyPathFallback',
+          reason: 'gateway hosted service list absent from current snapshot; retained hosted-service cache used',
+          sourceRefs: ['runtime.shared.state.hostedGatewaySnapshots'],
+          observedAt: nowMs(),
+          currentSnapshotUpdatedAt: current.updatedAt || 0,
+          cachedSnapshotUpdatedAt: cachedUpdatedAt,
+        },
+      }));
     } else if (current.updatedAt >= cachedUpdatedAt) {
       cache[current.pk] = {
         updatedAt: current.updatedAt,

--- a/runtime.worker.js
+++ b/runtime.worker.js
@@ -19,6 +19,8 @@ import {
   assertEventFabricProcessorContract,
   assertCybersecProcessorSeed,
   assertConsumerFloor,
+  assertContractTarget,
+  assertContractTargetRegistryPosture,
   assertMaterializationBudget,
   assertPrivateContentEnvelope,
   assertProjectionPolicy,
@@ -8134,6 +8136,246 @@ function serviceCatalog() {
   };
 }
 
+function pushValidatedRecord(out, seen, candidate, idKeys, validator, eventKind) {
+  if (!candidate || typeof candidate !== 'object' || Array.isArray(candidate)) return;
+  try {
+    const record = validator(safeClone(candidate));
+    const id = idKeys
+      .map((key) => String(record?.[key] || '').trim())
+      .find(Boolean)
+      || JSON.stringify(record);
+    if (!seen.has(id)) {
+      seen.add(id);
+      out.push(record);
+    }
+  } catch (error) {
+    recordRuntimeEvent(eventKind, {
+      level: 'warn',
+      error: { message: String(error?.message || error) },
+    });
+  }
+}
+
+function runtimeHostFabricRecordsFromCatalog(catalog) {
+  const fulfillmentPlans = [];
+  const memberContributions = [];
+  const lifecyclePlans = [];
+  const seenPlans = new Set();
+  const seenContributions = new Set();
+  const seenLifecyclePlans = new Set();
+  for (const service of normalizeArray(catalog?.services)) {
+    const fabric = service?.hostFabric && typeof service.hostFabric === 'object' ? service.hostFabric : {};
+    pushValidatedRecord(
+      fulfillmentPlans,
+      seenPlans,
+      fabric.fulfillmentPlan,
+      ['planId'],
+      assertHostFabricFulfillmentPlan,
+      'runtime.target.fabric_plan.ignored',
+    );
+    pushValidatedRecord(
+      memberContributions,
+      seenContributions,
+      fabric.gatewayAssociationContribution,
+      ['contributionId'],
+      assertHostFabricMemberContribution,
+      'runtime.target.fabric_contribution.ignored',
+    );
+    pushValidatedRecord(
+      lifecyclePlans,
+      seenLifecyclePlans,
+      fabric.lifecyclePlan,
+      ['lifecyclePlanId'],
+      assertLifecyclePlanPosture,
+      'runtime.target.lifecycle_plan.ignored',
+    );
+  }
+  return { fulfillmentPlans, memberContributions, lifecyclePlans };
+}
+
+function targetSlot(slotRef, state, platformFitState, candidateFulfillmentRefs = [], extra = {}) {
+  const selectedFulfillmentRef = String(extra.selectedFulfillmentRef || candidateFulfillmentRefs[0] || '').trim();
+  return {
+    slotRef,
+    state,
+    platformFitState,
+    candidateFulfillmentRefs: uniqueTrimmedStrings(candidateFulfillmentRefs),
+    ...(selectedFulfillmentRef ? { selectedFulfillmentRef } : {}),
+    sourceRefs: uniqueTrimmedStrings(extra.sourceRefs || []),
+    buildRefs: uniqueTrimmedStrings(extra.buildRefs || []),
+    platformRefs: uniqueTrimmedStrings(extra.platformRefs || []),
+    adapterRefs: uniqueTrimmedStrings(extra.adapterRefs || []),
+    proofRequirementRefs: uniqueTrimmedStrings(extra.proofRequirementRefs || []),
+    proofRefs: uniqueTrimmedStrings(extra.proofRefs || []),
+    evidenceRefs: uniqueTrimmedStrings(extra.evidenceRefs || []),
+    blockedReasons: uniqueTrimmedStrings(extra.blockedReasons || []),
+    safeFacts: extra.safeFacts && typeof extra.safeFacts === 'object' ? safeClone(extra.safeFacts) : undefined,
+  };
+}
+
+function runtimeContractTargetSource(catalog, sampledAt = nowMs()) {
+  const services = normalizeArray(catalog?.services);
+  const fabricRecords = runtimeHostFabricRecordsFromCatalog(catalog);
+  const serviceRefs = uniqueTrimmedStrings(services.map((service) => service?.serviceRef));
+  const serviceFulfillmentRefs = serviceRefs.map((ref) => `fulfillment:${ref}`);
+  const gatewayFulfillmentRefs = uniqueTrimmedStrings(
+    fabricRecords.memberContributions
+      .filter((contribution) => contribution.role === FABRIC.MEMBER_ROLE.GATEWAY_ASSOCIATION)
+      .map((contribution) => contribution.contributionId),
+  );
+  const runtimeRef = `runtime:${RUNTIME_WORKER_BUILD_ID}`;
+  const targetRef = 'contract-target:desktop-windows-dev:msa-transition';
+  const registryRef = 'contract-target-registry:desktop-windows-dev:msa-transition';
+  const missingSlotRefs = ['slot:native-client'];
+  const slotPostures = [
+    targetSlot(
+      'slot:runtime',
+      FABRIC.CONTRACT_TARGET_SLOT_STATE.AVAILABLE,
+      FABRIC.CONTRACT_TARGET_PLATFORM_FIT_STATE.COMPATIBLE,
+      [runtimeRef],
+      {
+        platformRefs: ['platform:browser-shared-worker'],
+        adapterRefs: ['adapter:runtime-shared-worker'],
+        evidenceRefs: [`evidence:${runtimeRef}`],
+      },
+    ),
+    targetSlot(
+      'slot:surface',
+      FABRIC.CONTRACT_TARGET_SLOT_STATE.AVAILABLE,
+      FABRIC.CONTRACT_TARGET_PLATFORM_FIT_STATE.COMPATIBLE,
+      ['surface:first-party-browser'],
+      {
+        platformRefs: ['platform:browser-window'],
+        adapterRefs: ['adapter:runtime-surface-client'],
+        evidenceRefs: ['evidence:surface:runtime-attach'],
+      },
+    ),
+    targetSlot(
+      'slot:gateway-association',
+      gatewayFulfillmentRefs.length
+        ? FABRIC.CONTRACT_TARGET_SLOT_STATE.AVAILABLE
+        : FABRIC.CONTRACT_TARGET_SLOT_STATE.DEGRADED,
+      gatewayFulfillmentRefs.length
+        ? FABRIC.CONTRACT_TARGET_PLATFORM_FIT_STATE.COMPATIBLE
+        : FABRIC.CONTRACT_TARGET_PLATFORM_FIT_STATE.DEGRADED,
+      gatewayFulfillmentRefs,
+      {
+        evidenceRefs: fabricRecords.memberContributions.flatMap((contribution) => normalizeArray(contribution.evidenceRefs)),
+        blockedReasons: gatewayFulfillmentRefs.length ? [] : ['gatewayAssociationContributionMissing'],
+      },
+    ),
+    targetSlot(
+      'slot:service-catalog',
+      serviceFulfillmentRefs.length
+        ? FABRIC.CONTRACT_TARGET_SLOT_STATE.AVAILABLE
+        : FABRIC.CONTRACT_TARGET_SLOT_STATE.DEGRADED,
+      serviceFulfillmentRefs.length
+        ? FABRIC.CONTRACT_TARGET_PLATFORM_FIT_STATE.COMPATIBLE
+        : FABRIC.CONTRACT_TARGET_PLATFORM_FIT_STATE.DEGRADED,
+      serviceFulfillmentRefs,
+      {
+        sourceRefs: ['projection:swarm.directory', 'projection:retained.services'],
+        evidenceRefs: ['evidence:runtime:service-catalog'],
+        blockedReasons: serviceFulfillmentRefs.length ? [] : ['serviceCatalogEmpty'],
+      },
+    ),
+    targetSlot(
+      'slot:native-client',
+      FABRIC.CONTRACT_TARGET_SLOT_STATE.MISSING,
+      FABRIC.CONTRACT_TARGET_PLATFORM_FIT_STATE.UNKNOWN,
+      [],
+      {
+        blockedReasons: ['nativeClientNotPresentOnDesktopDevTarget'],
+      },
+    ),
+  ];
+  const degradedSlotRefs = slotPostures
+    .filter((slot) => slot.state === FABRIC.CONTRACT_TARGET_SLOT_STATE.DEGRADED)
+    .map((slot) => slot.slotRef);
+  const blockedReasons = uniqueTrimmedStrings([
+    ...slotPostures.flatMap((slot) => normalizeArray(slot.blockedReasons)),
+  ]);
+  const target = assertContractTarget({
+    kind: SWARM.RECORD_KIND.CONTRACT_TARGET,
+    targetRef,
+    contractRef: 'app:constitution-runtime-target@msa-transition',
+    profileRef: 'target-profile:desktop-dev',
+    platformRef: 'platform:windows-desktop',
+    state: missingSlotRefs.length || degradedSlotRefs.length
+      ? FABRIC.CONTRACT_TARGET_STATE.DEGRADED
+      : FABRIC.CONTRACT_TARGET_STATE.READY,
+    compatibilityState: missingSlotRefs.length || degradedSlotRefs.length
+      ? FABRIC.CONTRACT_TARGET_COMPATIBILITY_STATE.DEGRADED
+      : FABRIC.CONTRACT_TARGET_COMPATIBILITY_STATE.COMPATIBLE,
+    hostRef: 'host:local-workstation',
+    substrateRef: 'substrate:desktop-windows',
+    modifierRefs: ['modifier:dev'],
+    branchRefs: ['branch:0x/msa-transition'],
+    subbranchRefs: ['subbranch:runtime-target-source'],
+    capabilitySlotRefs: slotPostures.map((slot) => slot.slotRef),
+    adapterPackRef: 'adapter-pack:browser-runtime-local',
+    adapterRefs: ['adapter:runtime-shared-worker', 'adapter:runtime-surface-client'],
+    missingSlotRefs,
+    degradedSlotRefs,
+    proofProfileRefs: ['proof-profile:surface-landscape'],
+    proofRefs: [],
+    compatibilityRefs: [`compat:${RUNTIME_WORKER_BUILD_ID}`],
+    evidenceRefs: ['evidence:runtime:target-source', `evidence:${runtimeRef}`],
+    blockedReasons,
+    targetAudience: 'operator',
+    safeFacts: {
+      runtimeBuildId: RUNTIME_WORKER_BUILD_ID,
+      source: 'runtime.snapshot',
+      serviceCount: services.length,
+    },
+    issuedAt: sampledAt,
+    expiresAt: sampledAt + 60_000,
+  });
+  const registry = assertContractTargetRegistryPosture({
+    kind: SWARM.RECORD_KIND.CONTRACT_TARGET_REGISTRY_POSTURE,
+    registryRef,
+    targetRef,
+    contractRef: target.contractRef,
+    state: missingSlotRefs.length || degradedSlotRefs.length
+      ? FABRIC.CONTRACT_TARGET_REGISTRY_STATE.DEGRADED
+      : FABRIC.CONTRACT_TARGET_REGISTRY_STATE.READY,
+    slotPostures,
+    candidateFulfillmentRefs: uniqueTrimmedStrings([
+      runtimeRef,
+      'surface:first-party-browser',
+      ...gatewayFulfillmentRefs,
+      ...serviceFulfillmentRefs,
+    ]),
+    sourceRefs: ['projection:swarm.directory', 'projection:retained.services'],
+    buildRefs: [],
+    adapterRefs: target.adapterRefs,
+    proofRequirementRefs: ['proof-requirement:surface-landscape'],
+    proofRefs: [],
+    evidenceRefs: ['evidence:runtime:target-registry', ...target.evidenceRefs],
+    blockedReasons,
+    safeFacts: {
+      runtimeBuildId: RUNTIME_WORKER_BUILD_ID,
+      source: 'runtime.snapshot',
+      serviceCount: services.length,
+    },
+    observedAt: sampledAt,
+    expiresAt: sampledAt + 60_000,
+  });
+  return {
+    kind: 'runtime.contract-target.source',
+    state: registry.state,
+    targetRef,
+    registryRef,
+    contractTargets: [target],
+    targetRegistryPostures: [registry],
+    hostFabricFulfillmentPlans: fabricRecords.fulfillmentPlans,
+    hostFabricContributions: fabricRecords.memberContributions,
+    lifecyclePlans: fabricRecords.lifecyclePlans,
+    blockedReasons,
+    observedAt: sampledAt,
+  };
+}
+
 function liveDirectoryPayloads() {
   const out = [];
   for (const projection of retainedProjections.values()) {
@@ -9452,6 +9694,8 @@ function rebuildManagedApplianceSnapshot() {
 
 function runtimeSnapshot() {
   const brokerEndpoint = brokerClientId ? endpoints.get(brokerClientId) : null;
+  const catalog = serviceCatalog();
+  const targetSource = runtimeContractTargetSource(catalog);
   const snapshot = {
     buildId: RUNTIME_WORKER_BUILD_ID,
     updatedAt: runtimeUpdatedAt || nowMs(),
@@ -9464,7 +9708,13 @@ function runtimeSnapshot() {
     managedAppliances: safeClone(managedState.applianceSnapshot),
     resourceNames: safeClone(managedState.resourceNames),
     managedServiceIssue: safeClone(managedState.managedServiceIssue),
-    serviceCatalog: serviceCatalog(),
+    serviceCatalog: catalog,
+    targetSource,
+    contractTargets: safeClone(targetSource.contractTargets),
+    targetRegistryPostures: safeClone(targetSource.targetRegistryPostures),
+    hostFabricFulfillmentPlans: safeClone(targetSource.hostFabricFulfillmentPlans),
+    hostFabricContributions: safeClone(targetSource.hostFabricContributions),
+    lifecyclePlans: safeClone(targetSource.lifecyclePlans),
     edge: edgeSnapshot(),
     swarmQueue: swarmQueueObject(),
     activationResolutions: activationResolutionObject(),

--- a/runtime.worker.js
+++ b/runtime.worker.js
@@ -1,5 +1,6 @@
 import {
   AGREEMENT,
+  FABRIC,
   PROJECTION,
   SERVICE_REGISTRY,
   SWARM,
@@ -25,7 +26,11 @@ import {
   assertProjectionSnapshot,
   assertServiceRegistryClaim,
   assertServiceRegistryMaterialization,
+  assertHostFabricFulfillmentPlan,
+  assertHostFabricMemberContribution,
+  assertLifecyclePlanPosture,
   assertResolvedMemberRef,
+  assertSubstrateAssociationHandoff,
   assertProjectionRepairPosture,
   assertResourcePosture,
   assertResourceProfile,
@@ -7679,6 +7684,69 @@ function serviceRecordHealth(record) {
   return safeClone(health);
 }
 
+function serviceRecordGatewayAssociationPosture(record) {
+  const posture = record?.gatewayAssociationPosture || record?.gateway_association_posture;
+  return posture && typeof posture === 'object' ? posture : null;
+}
+
+function serviceRecordHostFabricPosture(record) {
+  const posture = serviceRecordGatewayAssociationPosture(record);
+  if (!posture) return null;
+  try {
+    const substrateAssociationHandoff = assertSubstrateAssociationHandoff(safeClone(
+      posture.substrateAssociationHandoff || posture.substrate_association_handoff,
+    ));
+    const gatewayAssociationContribution = assertHostFabricMemberContribution(safeClone(
+      posture.gatewayAssociationContribution || posture.gateway_association_contribution,
+    ));
+    const lifecyclePlan = assertLifecyclePlanPosture(safeClone(
+      posture.lifecyclePlan || posture.lifecycle_plan,
+    ));
+    const fulfillmentPlan = assertHostFabricFulfillmentPlan(safeClone(
+      posture.fulfillmentPlan || posture.fulfillment_plan,
+    ));
+    const blockedReasons = uniqueTrimmedStrings([
+      ...normalizeArray(substrateAssociationHandoff.blockedReasons),
+      ...normalizeArray(gatewayAssociationContribution.blockedReasons),
+      ...normalizeArray(lifecyclePlan.blockedReasons),
+      ...normalizeArray(fulfillmentPlan.blockedReasons),
+      ...normalizeArray(fulfillmentPlan.missingRoleRefs).map((ref) => `missing:${ref}`),
+    ]);
+    const evidenceRefs = uniqueTrimmedStrings([
+      ...normalizeArray(substrateAssociationHandoff.evidenceRefs),
+      ...normalizeArray(gatewayAssociationContribution.evidenceRefs),
+      ...normalizeArray(lifecyclePlan.evidenceRefs),
+      ...normalizeArray(fulfillmentPlan.evidenceRefs),
+    ]);
+    return {
+      state: fulfillmentPlan.state || lifecyclePlan.state || gatewayAssociationContribution.state,
+      fabricRef: fulfillmentPlan.fabricRef || gatewayAssociationContribution.fabricRef || substrateAssociationHandoff.fabricRef,
+      hostRef: fulfillmentPlan.hostRef || gatewayAssociationContribution.hostRef || substrateAssociationHandoff.hostRef,
+      associationHandoffRef: fulfillmentPlan.associationHandoffRef || substrateAssociationHandoff.handoffId,
+      gatewayAssociationRefs: normalizeArray(substrateAssociationHandoff.gatewayAssociationRefs),
+      memberContributionRefs: normalizeArray(fulfillmentPlan.memberContributionRefs),
+      lifecyclePlanRefs: normalizeArray(fulfillmentPlan.lifecyclePlanRefs),
+      requiredRoleRefs: normalizeArray(fulfillmentPlan.requiredRoleRefs),
+      missingRoleRefs: normalizeArray(fulfillmentPlan.missingRoleRefs),
+      blockedReasons,
+      evidenceRefs,
+      substrateAssociationHandoff,
+      gatewayAssociationContribution,
+      lifecyclePlan,
+      fulfillmentPlan,
+    };
+  } catch (error) {
+    recordRuntimeEvent('runtime.msa.gateway_association.ignored', {
+      level: 'warn',
+      service: serviceRecordService(record),
+      servicePk: serviceRecordServicePk(record),
+      hostGatewayPk: serviceRecordHostGatewayPk(record),
+      error: { message: String(error?.message || error) },
+    });
+    return null;
+  }
+}
+
 function normalizeServiceZoneScope(value) {
   if (!value) return null;
   const source = value && typeof value === 'object' ? value : { zoneId: value };
@@ -7832,6 +7900,9 @@ function hostedServiceRecords() {
           hostGatewayLabel: hosted.hostGatewayLabel || hostGatewayLabel,
           identityId: serviceRecordIdentityId(hosted) || serviceRecordIdentityId(record) || undefined,
           zoneScope: serviceRecordZoneScope(hosted) || hostGatewayZoneScope || undefined,
+          gatewayAssociationPosture: serviceRecordGatewayAssociationPosture(hosted)
+            || serviceRecordGatewayAssociationPosture(record)
+            || undefined,
         };
         const service = serviceRecordService(merged);
         const servicePk = serviceRecordServicePk(merged);
@@ -7861,6 +7932,7 @@ function serviceDescriptorFromRecord(record) {
     surfaceChannel,
     summary: serviceRecordSummary(record),
     health: serviceRecordHealth(record),
+    hostFabric: serviceRecordHostFabricPosture(record),
     nodes: serviceRecordNodes(record),
   };
 }
@@ -7903,8 +7975,16 @@ function serviceRegistryClaimFromDescriptor(descriptor, issuedAt = nowMs()) {
       evidenceRefs: uniqueTrimmedStrings([
         descriptor.liveEdgeRoute?.memberRef ? `swarm.directory:${descriptor.liveEdgeRoute.memberRef}` : '',
         descriptor.surfaceChannel ? `projection:${descriptor.surfaceChannel}` : '',
+        descriptor.hostFabric?.associationHandoffRef,
+        ...normalizeArray(descriptor.hostFabric?.memberContributionRefs),
+        ...normalizeArray(descriptor.hostFabric?.lifecyclePlanRefs),
+        ...normalizeArray(descriptor.hostFabric?.evidenceRefs),
       ]),
-      safeFacts: { service, surfaceChannel: descriptor.surfaceChannel || '' },
+      safeFacts: {
+        service,
+        surfaceChannel: descriptor.surfaceChannel || '',
+        hostFabricState: descriptor.hostFabric?.state || '',
+      },
       issuedAt,
       expiresAt: issuedAt + 90_000,
     });
@@ -9181,6 +9261,10 @@ function mergeGatewayHostedServiceRecord(actualRecord, hostedRecord, gatewayReco
     hostGatewayPk: gatewayPk,
     serviceVersion: String(hosted.serviceVersion || hosted.service_version || actual.serviceVersion || actual.service_version || '').trim(),
     swarmEdge: hosted.swarmEdge || hosted.swarm_edge || actual.swarmEdge || actual.swarm_edge || undefined,
+    gatewayAssociationPosture: serviceRecordGatewayAssociationPosture(hosted)
+      || serviceRecordGatewayAssociationPosture(actual)
+      || serviceRecordGatewayAssociationPosture(gateway)
+      || undefined,
     updatedAt: hostedUpdatedAt,
     freshnessMs: Number(hosted.freshnessMs || hosted.freshness_ms || actual.freshnessMs || actual.freshness_ms || 0),
     status: String(hosted.status || actual.status || '').trim(),


### PR DESCRIPTION
Moves Account runtime state toward shared target/read-model posture and relay/service evidence consumption.\n\nProof: local Account tests/build, browser, convergence, affected, aggregate, and 10-minute media/resource proof passed.